### PR TITLE
MCP : erreurs structurées, pannes de source visibles, secrets hors conversation, pagination annoncée

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Les outils juridiques propriétaires (**Pappers Justice**, **Doctrine.fr**, **Le
 | **Conseil constit.** | ✅ 7k décisions + tool dédié | ⚠️ | ❌ | ⚠️ | ✅ |
 | **40 TA en parallèle** | ✅ fan-out | ⚠️ partiel | ❌ | ❌ | ✅ |
 | **9 CAA en parallèle** | ✅ fan-out | ⚠️ | ❌ | ❌ | ✅ |
-| **CNIL délibérations** | ✅ 26k | ❌ | ❌ | ⚠️ | ❌ |
+| **CNIL délibérations** | ✅ ~8k | ❌ | ❌ | ⚠️ | ❌ |
 | **Articles loi versionnés** | ✅ 1.5M | ⚠️ | ⚠️ Légifrance brut | ⚠️ | ✅ |
 | **BM25 pertinence** | ✅ | ⚠️ | ⚠️ | ⚠️ | ✅ |
 | **Open source** | ✅ MIT | ❌ | ⚠️ | ❌ | ❌ |
@@ -127,7 +127,7 @@ Les outils juridiques propriétaires (**Pappers Justice**, **Doctrine.fr**, **Le
 |---|---|
 | `search_jorf` | 1.24M textes JO (lois, décrets, arrêtés, circulaires depuis 1990) |
 | `search_kali` | 335k conventions collectives + accords de branche |
-| `search_cnil` | 26k délibérations CNIL (RGPD, données personnelles) |
+| `search_cnil` | ~8k délibérations CNIL (RGPD, données personnelles) |
 
 ---
 

--- a/server.py
+++ b/server.py
@@ -28,6 +28,7 @@ from typing import Any
 
 import httpx
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
 from sources import (
     ariane, dila, european, judilibre, juriadmin, legi,
@@ -222,7 +223,8 @@ def _client() -> httpx.AsyncClient:
     )
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(
+    title="À propos de JusticeLibre", readOnlyHint=True))
 async def about_justicelibre() -> dict[str, Any]:
     """Vue d'ensemble du protocole JusticeLibre : cartographie des sources
     et règles d'acheminement.
@@ -341,7 +343,8 @@ async def about_justicelibre() -> dict[str, Any]:
     }
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(
+    title="Liste des juridictions couvertes", readOnlyHint=True))
 async def list_juridictions() -> dict[str, Any]:
     """Référentiel exhaustif des codes juridictionnels.
 
@@ -365,7 +368,8 @@ async def list_juridictions() -> dict[str, Any]:
     }
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(
+    title="Recherche Conseil d'État (ArianeWeb)", readOnlyHint=True))
 async def search_conseil_etat(query: str, limit: int = 20, offset: int = 0) -> dict[str, Any]:
     """Recherche sémantique ciblée sur la jurisprudence du Conseil d'État
     (base ArianeWeb, ~270 000 décisions).
@@ -400,7 +404,8 @@ async def search_conseil_etat(query: str, limit: int = 20, offset: int = 0) -> d
         return await ariane.search(client, query=query, limit=limit, skip=offset)
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(
+    title="Décisions administratives récentes", readOnlyHint=True))
 async def search_admin_recent(
     query: str,
     juridiction: str = "CE",
@@ -438,7 +443,8 @@ async def search_admin_recent(
         )
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(
+    title="Décisions récentes des 40 TA", readOnlyHint=True))
 async def search_admin_recent_all_ta(
     query: str,
     limit_per_court: int = 5,
@@ -478,7 +484,8 @@ async def search_admin_recent_all_ta(
     return result
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(
+    title="Décisions récentes des 9 CAA", readOnlyHint=True))
 async def search_admin_recent_all_caa(
     query: str,
     limit_per_court: int = 5,
@@ -554,7 +561,8 @@ def _dec_cache_put(key: str, val: Any) -> None:
     _DEC_CACHE[key] = (time.time(), val)
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(
+    title="Texte intégral d'une décision administrative", readOnlyHint=True))
 async def get_decision_text(decision_id: str) -> dict[str, Any] | None:
     """Extraction du texte intégral d'une décision relevant de l'ordre
     administratif (Conseil d'État, TA, CAA).
@@ -666,7 +674,8 @@ async def get_decision_text(decision_id: str) -> dict[str, Any] | None:
 
 # ─── JUSTICE JUDICIAIRE - DILA (sans auth, index local) ──────────
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(
+    title="Recherche judiciaire (bulk DILA, sans auth)", readOnlyHint=True))
 async def search_judiciaire_libre(
     query: str = "",
     juridiction: str = "",
@@ -723,7 +732,8 @@ async def search_judiciaire_libre(
     )
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(
+    title="Texte intégral d'une décision judiciaire (DILA)", readOnlyHint=True))
 async def get_decision_judiciaire_libre(
     decision_id: str,
 ) -> dict[str, Any] | None:
@@ -769,7 +779,8 @@ _NO_CREDS_MSG = (
 )
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(
+    title="Recherche judiciaire (PISTE Judilibre)", readOnlyHint=True))
 async def search_judiciaire(
     query: str,
     session_token: str = "",
@@ -842,7 +853,8 @@ async def search_judiciaire(
         )
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(
+    title="Texte intégral d'une décision (PISTE Judilibre)", readOnlyHint=True))
 async def get_decision_judiciaire(
     decision_id: str,
     session_token: str = "",
@@ -900,7 +912,8 @@ async def get_decision_judiciaire(
 
 # ─── COURS EUROPÉENNES (CJUE + CEDH) — index local, sans auth ────
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(
+    title="Résolution d'un numéro de loi ou décret", readOnlyHint=True))
 async def resolve_law_number(numero: str) -> dict[str, Any]:
     """Résout un numéro de loi/ordonnance/décret vers son identifiant LEGITEXT
     ou JORFTEXT Légifrance.
@@ -928,7 +941,8 @@ async def resolve_law_number(numero: str) -> dict[str, Any]:
     return await legi.resolve_number(numero)
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(
+    title="URL Légifrance canonique", readOnlyHint=True))
 async def build_source_url(identifier: str, legitext: str = "", date: str = "") -> dict[str, Any]:
     """Construit l'URL canonique d'un document à partir de son identifiant.
 
@@ -969,7 +983,8 @@ async def build_source_url(identifier: str, legitext: str = "", date: str = "") 
     return {"id": identifier, "source_url": url}
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(
+    title="Décision du Conseil constitutionnel par numéro", readOnlyHint=True))
 async def get_cc_decision(numero: str, nature: str = "") -> dict[str, Any] | None:
     """Récupère une décision du Conseil constitutionnel par son numéro.
 
@@ -988,7 +1003,8 @@ async def get_cc_decision(numero: str, nature: str = "") -> dict[str, Any] | Non
     return dila.get_cc_decision(numero, nature or None)
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(
+    title="Décision du Conseil d'État par numéro", readOnlyHint=True))
 async def get_ce_decision(numero: str) -> dict[str, Any] | None:
     """Récupère une décision du Conseil d'État par son numéro de pourvoi.
 
@@ -1008,7 +1024,8 @@ async def get_ce_decision(numero: str) -> dict[str, Any] | None:
     return await jade_remote.get_ce_decision(numero)
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(
+    title="Décision administrative par numéro de requête", readOnlyHint=True))
 async def get_admin_decision(numero: str, juridiction: str = "") -> dict[str, Any]:
     """Récupère une décision administrative par son **numéro de requête exact**.
 
@@ -1054,7 +1071,8 @@ async def get_admin_decision(numero: str, juridiction: str = "") -> dict[str, An
     return result
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(
+    title="Recherche Conseil constitutionnel", readOnlyHint=True))
 async def search_cc(
     query: str,
     nature: str = "",
@@ -1103,7 +1121,8 @@ async def search_cc(
     )
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(
+    title="Recherche Cour EDH", readOnlyHint=True))
 async def search_cedh(query: str, limit: int = 20) -> dict[str, Any]:
     """Recherche textuelle dans la jurisprudence de la Cour européenne des
     droits de l'homme.
@@ -1120,7 +1139,8 @@ async def search_cedh(query: str, limit: int = 20) -> dict[str, Any]:
     return european.search_cedh(query=query, limit=limit)
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(
+    title="Texte intégral d'une décision CEDH", readOnlyHint=True))
 async def get_decision_cedh(decision_id: str) -> dict[str, Any] | None:
     """Extraction du texte intégral d'une décision de la Cour européenne des
     droits de l'homme sur la base de son identifiant système (itemid HUDOC).
@@ -1132,7 +1152,8 @@ async def get_decision_cedh(decision_id: str) -> dict[str, Any] | None:
     return european.get_cedh(decision_id)
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(
+    title="Recherche CJUE", readOnlyHint=True))
 async def search_cjue(query: str, limit: int = 20) -> dict[str, Any]:
     """Recherche textuelle dans la jurisprudence de la Cour de justice de
     l'Union européenne.
@@ -1149,7 +1170,8 @@ async def search_cjue(query: str, limit: int = 20) -> dict[str, Any]:
     return european.search_cjue(query=query, limit=limit)
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(
+    title="Texte intégral d'un arrêt CJUE", readOnlyHint=True))
 async def get_decision_cjue(decision_id: str) -> dict[str, Any] | None:
     """Extraction du texte intégral d'une décision de la Cour de justice de
     l'Union européenne sur la base de son identifiant normalisé (CELEX).
@@ -1170,7 +1192,8 @@ async def get_decision_cjue(decision_id: str) -> dict[str, Any] | None:
 # par date. Préférer ces outils pour trouver la jurisprudence
 # pertinente sur un sujet.
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(
+    title="Recherche administrative (JADE, BM25)", readOnlyHint=True))
 async def search_admin(
     query: str,
     juridiction: str = "",
@@ -1217,7 +1240,8 @@ async def search_admin(
     )
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(
+    title="Recherche articles de loi (LEGI)", readOnlyHint=True))
 async def search_legi(
     query: str,
     code: str = "",
@@ -1267,7 +1291,8 @@ async def search_legi(
     }
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(
+    title="Recherche Journal officiel (JORF)", readOnlyHint=True))
 async def search_jorf(
     query: str,
     nature: str = "",
@@ -1298,7 +1323,8 @@ async def search_jorf(
     )
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(
+    title="Recherche conventions collectives (KALI)", readOnlyHint=True))
 async def search_kali(
     query: str,
     idcc: str = "",
@@ -1323,7 +1349,8 @@ async def search_kali(
     )
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(
+    title="Recherche délibérations CNIL", readOnlyHint=True))
 async def search_cnil(
     query: str,
     limit: int = 20,
@@ -1345,7 +1372,8 @@ async def search_cnil(
 # du Code civil en 1992 = texte napoléonien, pas la réforme 2016).
 # C'est le "killer feature" que Dalloz vend 200€/mois, exposé ici gratis.
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(
+    title="Article de loi à une date donnée", readOnlyHint=True))
 async def get_law_article(code: str, num: str, date: str = "") -> dict[str, Any]:
     """Renvoie le texte d'un article de loi à une date donnée (ou version
     actuelle si `date` vide).
@@ -1379,7 +1407,8 @@ async def get_law_article(code: str, num: str, date: str = "") -> dict[str, Any]
     return result
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(
+    title="Versions historiques d'un article de loi", readOnlyHint=True))
 async def get_law_versions(code: str, num: str) -> dict[str, Any]:
     """Renvoie toutes les versions historiques d'un article de loi, du plus
     ancien au plus récent.
@@ -1404,7 +1433,8 @@ async def get_law_versions(code: str, num: str) -> dict[str, Any]:
     return result
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(
+    title="Décisions citant un article de loi", readOnlyHint=True))
 async def search_decisions_citing(
     code: str,
     num: str,
@@ -1524,7 +1554,8 @@ async def search_decisions_citing(
 
 # ─── TOOL UNIFIÉ : search_all ──────────────────────────────────────
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(
+    title="Recherche fédérée toutes sources", readOnlyHint=True))
 async def search_all(
     query: str,
     sources: list[str] | None = None,

--- a/server.py
+++ b/server.py
@@ -17,6 +17,7 @@ into Claude Desktop / Cursor / any MCP client.
 """
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import re
@@ -37,7 +38,7 @@ from sources import (
 
 mcp = FastMCP(
     "justicelibre",
-    instructions="""Protocole d'accès libre à la jurisprudence et au droit positif français + européen (24 tools).
+    instructions="""Protocole d'accès libre à la jurisprudence et au droit positif français + européen (30 tools).
 
 TOOL D'ENTRÉE : `search_all` — recherche fédérée fan-out avec ranking BM25
 + thésaurus juridique FR automatique (ex : "harcèlement" → aussi
@@ -57,8 +58,7 @@ complet. Pour lire une décision en entier, TOUJOURS enchaîner avec le tool
 d'extraction correspondant à l'id renvoyé. Ne JAMAIS conclure « texte
 indisponible / pas dans la base » à partir d'un snippet seul, ni rediriger
 l'utilisateur vers Légifrance sans avoir tenté l'extraction. Ces tools
-peuvent être "deferred" (absents de la liste visible) → les charger via
-tool_search avant de les appeler.
+peuvent être chargés à la demande par certains clients MCP.
 • `get_decision_text` (admin : DCE_*/DTA_*/DCAA_*/CETATEXT*/Ariane_Web)
 • `get_decision_judiciaire_libre` (judiciaire : JURITEXT*/CONSTEXT*)
 • `get_decision_cedh` (001-*)   • `get_decision_cjue` (CELEX/ECLI)
@@ -67,7 +67,8 @@ ARTICLES DE LOI (killer feature unique à justicelibre) :
 • `get_law_article(code, num, date)` — version en vigueur À LA DATE donnée.
   Ex : art. 1128 CC en 1992 → texte napoléonien, pas la réforme 2016.
 • `get_law_versions(code, num)` — timeline complète historique.
-• `search_legi` — 1,75 M articles des 72 codes consolidés.
+• `search_legi` — ~1,5 M articles (22 codes consolidés + Constitution
+  + 3 lois non codifiées).
 • `search_decisions_citing(code, num)` — cross-référence inverse.
 
 DROIT POSITIF COMPLÉMENTAIRE :
@@ -87,9 +88,9 @@ justicelibre.org/tutoriel-piste.html.
 
 PROTOCOLE D'USAGE : pour tout doute, commencer par `about_justicelibre`
 qui détaille la cartographie. Sinon : `search_all(query)` couvre 90% des
-besoins. 72 codes de loi consolidés supportés (CC, CP, CPC, CPP, CT, CSP,
-CJA, CGI, LPF, COJ, CGFP, CESEDA, CCP… liste complète via
-`about_justicelibre` ou `search_legi`).
+besoins. 26 codes/textes supportés : 22 codes consolidés (CC, CP, CPC,
+CPP, CT, CSP, CJA, CGI, CESEDA…) + Constitution + 3 lois non codifiées
+(liste complète via `about_justicelibre` ou `search_legi`).
 """,
 )
 
@@ -223,6 +224,36 @@ def _client() -> httpx.AsyncClient:
     )
 
 
+def _tool_error(message, *, category, retryable=False, **extra):
+    """Réponse d'erreur uniforme : message actionnable + catégorie + retryable.
+
+    category : "validation" (paramètres invalides, ne pas retenter à l'identique),
+    "not_found" (résultat vide légitime, l'objet n'existe pas dans la base),
+    "upstream" (source de données en échec — timeout, 5xx : retenter peut réussir),
+    "auth" (jeton expiré/invalide).
+    """
+    out = {"error": message, "error_category": category, "retryable": retryable}
+    out.update(extra)
+    return out
+
+
+def _annotate_pagination(data, limit, offset, results_key):
+    """Annonce la troncature au modèle : si le total dépasse ce qui a été
+    renvoyé, ajoute `truncated` + `next_offset` pour signaler qu'il reste
+    des résultats à paginer (au lieu de laisser croire à une liste complète)."""
+    if not isinstance(data, dict):
+        return data
+    results = data.get(results_key)
+    if not isinstance(results, list):
+        return data
+    total = data.get("total", 0)
+    returned = len(results)
+    if isinstance(total, int) and total > offset + returned:
+        data["truncated"] = True
+        data["next_offset"] = offset + returned
+    return data
+
+
 @mcp.tool(annotations=ToolAnnotations(
     title="À propos de JusticeLibre", readOnlyHint=True))
 async def about_justicelibre() -> dict[str, Any]:
@@ -254,7 +285,7 @@ async def about_justicelibre() -> dict[str, Any]:
             },
             "2_admin_pertinence": {
                 "tools": ["search_admin", "list_juridictions"],
-                "volume": "~4M décisions JADE : CE + 9 CAA + 40 TA full text",
+                "volume": "~550 000 décisions JADE : CE + 9 CAA + 40 TA full text",
                 "strengths": "Ranking BM25 (vraie pertinence) + snippets + date range. REMPLACE les tools date-sorted pour trouver la jurisprudence pertinente.",
                 "id_format": "DCE_*, DTA_*, DCAA_*",
                 "id_compatible_with": "get_decision_text",
@@ -265,7 +296,7 @@ async def about_justicelibre() -> dict[str, Any]:
             },
             "3_dila_judiciaire": {
                 "tools": ["search_judiciaire_libre", "get_decision_judiciaire_libre"],
-                "volume": "~620 000 décisions : Cour de cassation + 36 Cours d'appel + Conseil constitutionnel (archives DILA locales)",
+                "volume": "~1,17 M décisions : Cour de cassation + 36 Cours d'appel + Conseil constitutionnel (archives DILA locales)",
                 "strengths": "Index local FTS5, aucune auth. Opérateurs FTS5 (phrase exacte, AND, OR, préfixe*).",
                 "id_format": "JURITEXT*, CONSTEXT*, JURI*",
                 "id_compatible_with": "get_decision_judiciaire_libre",
@@ -293,7 +324,7 @@ async def about_justicelibre() -> dict[str, Any]:
             },
             "7_articles_loi": {
                 "tools": ["get_law_article", "get_law_versions", "search_legi", "search_decisions_citing"],
-                "volume": "~3,6 Go bulk LEGI : 22 codes consolidés (CC, CP, CT, etc.) AVEC toutes les versions historiques",
+                "volume": "~3,6 Go bulk LEGI : 26 codes/textes (22 codes consolidés — CC, CP, CT, etc. — + Constitution + 3 lois non codifiées) AVEC toutes les versions historiques",
                 "strengths": "**Killer feature** : récupérer un article à sa version en vigueur à une date précise. Ex: art. 1128 CC en 1992 → texte napoléonien ; en 2024 → texte réforme 2016. Ce que Dalloz facture 200€/mois.",
                 "id_format": "LEGIARTI*",
                 "id_compatible_with": "get_law_article / get_law_versions",
@@ -311,7 +342,7 @@ async def about_justicelibre() -> dict[str, Any]:
             },
             "10_cnil": {
                 "tools": ["search_cnil"],
-                "volume": "~26 000 délibérations CNIL",
+                "volume": "~8 000 délibérations CNIL",
                 "strengths": "Droit des données personnelles (RGPD).",
             },
         },
@@ -400,8 +431,15 @@ async def search_conseil_etat(query: str, limit: int = 20, offset: int = 0) -> d
             offset=40, etc. pour obtenir les pages suivantes.
     """
     _record_call("search_conseil_etat")
+    if not query.strip():
+        return _tool_error(
+            "Le paramètre query est requis (2-5 mots-clés distinctifs, ex : "
+            "\"référé liberté\").",
+            category="validation",
+        )
     async with _client() as client:
-        return await ariane.search(client, query=query, limit=limit, skip=offset)
+        result = await ariane.search(client, query=query, limit=limit, skip=offset)
+    return _annotate_pagination(result, limit, offset, "decisions")
 
 
 @mcp.tool(annotations=ToolAnnotations(
@@ -448,7 +486,7 @@ async def search_admin_recent(
 async def search_admin_recent_all_ta(
     query: str,
     limit_per_court: int = 5,
-    total_limit: int = 0,
+    total_limit: int = 60,
 ) -> dict[str, Any]:
     """Requête simultanée de l'ensemble des 40 Tribunaux Administratifs.
 
@@ -460,10 +498,10 @@ async def search_admin_recent_all_ta(
     Args:
         query: mots-clés de recherche
         limit_per_court: nombre de résultats par tribunal (défaut 5, soit
-            jusqu'à 200 résultats totaux en l'absence de `total_limit`)
-        total_limit: plafond global après fusion (0 = aucun plafond). Si
-            positif, tronque la liste fusionnée aux N entrées les plus
-            récentes.
+            jusqu'à 200 résultats totaux avant application de `total_limit`)
+        total_limit: plafond global après fusion (défaut 60 ; 0 = aucun
+            plafond). Si positif, tronque la liste fusionnée aux N entrées
+            les plus récentes.
 
     Returns:
         Dict comportant `per_court_totals` (nombre de hits par TA),
@@ -563,7 +601,7 @@ def _dec_cache_put(key: str, val: Any) -> None:
 
 @mcp.tool(annotations=ToolAnnotations(
     title="Texte intégral d'une décision administrative", readOnlyHint=True))
-async def get_decision_text(decision_id: str) -> dict[str, Any] | None:
+async def get_decision_text(decision_id: str) -> dict[str, Any]:
     """Extraction du texte intégral d'une décision relevant de l'ordre
     administratif (Conseil d'État, TA, CAA).
 
@@ -586,9 +624,10 @@ async def get_decision_text(decision_id: str) -> dict[str, Any] | None:
         decision_id: identifiant de la décision (avec ou sans suffixe .xml)
 
     Returns:
-        Dict comportant les métadonnées complètes, `text_segments` (liste
-        des paragraphes) et `full_text` (texte intégral joint), ou None si
-        la décision est introuvable.
+        Dict comportant les métadonnées complètes et `full_text` (texte
+        intégral). Si la décision est introuvable, dict d'erreur structuré
+        `{error, error_category: "not_found", retryable}` avec les tools
+        alternatifs à essayer.
     """
     _record_call("get_decision_text")
     cached = _dec_cache_get(f"text:{decision_id}")
@@ -607,11 +646,12 @@ async def get_decision_text(decision_id: str) -> dict[str, Any] | None:
         async with _client() as client:
             text = await ariane.fetch_full_text(client, aid)
         if not text:
-            return {"error": (
+            return _tool_error(
                 f"Décision ArianeWeb {aid!r} introuvable ou texte indisponible "
                 "(plugin Sinequa muet). Vérifier l'identifiant via "
-                "`search_conseil_etat`."
-            )}
+                "`search_conseil_etat`.",
+                category="not_found",
+            )
         meta = _parse_ariane_header(text)
         result = {
             "id": aid,
@@ -620,26 +660,28 @@ async def get_decision_text(decision_id: str) -> dict[str, Any] | None:
             "numero": meta.get("numero", ""),
             "ecli": meta.get("ecli", ""),
             "date": meta.get("date", ""),
-            "text_segments": [s for s in text.split("\n\n") if s.strip()],
             "full_text": text,
         }
         _dec_cache_put(f"text:{decision_id}", result)
         return result
     if decision_id.startswith("JURITEXT") or decision_id.startswith("JURI"):
-        return {"error": (
+        return _tool_error(
             f"L'identifiant fourni ({decision_id!r}) relève du format JURITEXT (ordre judiciaire). "
-            "Recourir à `get_decision_judiciaire_libre(decision_id)` en remplacement."
-        )}
+            "Recourir à `get_decision_judiciaire_libre(decision_id)` en remplacement.",
+            category="validation",
+        )
     if decision_id.startswith(("6", "7", "8", "9")) and any(x in decision_id for x in ("CJ", "TJ", "CO", "CC")):
-        return {"error": (
+        return _tool_error(
             f"L'identifiant fourni ({decision_id!r}) correspond à un CELEX européen. "
-            "Recourir à `get_decision_cjue(decision_id)` en remplacement."
-        )}
+            "Recourir à `get_decision_cjue(decision_id)` en remplacement.",
+            category="validation",
+        )
     if decision_id.startswith("001-") or decision_id.startswith("002-") or decision_id.startswith("003-"):
-        return {"error": (
+        return _tool_error(
             f"L'identifiant fourni ({decision_id!r}) correspond à un itemid HUDOC (Cour EDH). "
-            "Recourir à `get_decision_cedh(decision_id)` en remplacement."
-        )}
+            "Recourir à `get_decision_cedh(decision_id)` en remplacement.",
+            category="validation",
+        )
     # JADE bulk local : les id CETATEXT… (renvoyés par search_admin) sont la clé
     # primaire de jade_decisions, texte intégral inclus. Lookup direct dans le
     # bulk — l'API elastic externe ci-dessous ne connaît pas ce format d'id et
@@ -649,8 +691,6 @@ async def get_decision_text(decision_id: str) -> dict[str, Any] | None:
         row = await wh.get_decision_remote("jade", decision_id)
         if row and (row.get("texte") or "").strip():
             text = row["texte"]
-            segs = [p.strip() for p in re.split(r"\n\s*\n", text) if p.strip()] \
-                or [l for l in text.split("\n") if l.strip()]
             result = {
                 "id": row.get("id"),
                 "source": "jade_bulk",
@@ -660,7 +700,6 @@ async def get_decision_text(decision_id: str) -> dict[str, Any] | None:
                 "date": row.get("date"),
                 "titre": row.get("titre"),
                 "sommaire": row.get("sommaire") or "",
-                "text_segments": segs,
                 "full_text": text,
             }
             _dec_cache_put(f"text:{decision_id}", result)
@@ -668,6 +707,19 @@ async def get_decision_text(decision_id: str) -> dict[str, Any] | None:
         # absent du bulk → on tente quand même l'API externe ci-dessous
     async with _client() as client:
         result = await juriadmin.get_decision(client, decision_id=decision_id)
+    if result is None:
+        return _tool_error(
+            f"Décision {decision_id!r} introuvable (bulk JADE local + API "
+            "opendata). Vérifier l'identifiant via `search_admin` (BM25) ou "
+            "`get_admin_decision(numero)` pour un lookup par numéro de "
+            "requête ; pour un arrêt CE d'intérêt jurisprudentiel, tenter "
+            "`search_conseil_etat` (ArianeWeb).",
+            category="not_found",
+        )
+    # La couche juriadmin renvoie text_segments + full_text (2x le même
+    # texte) : on ne garde que full_text pour économiser les tokens.
+    if isinstance(result, dict) and result.get("full_text"):
+        result.pop("text_segments", None)
     _dec_cache_put(f"text:{decision_id}", result)
     return result
 
@@ -683,12 +735,13 @@ async def search_judiciaire_libre(
     date_min: str = "",
     date_max: str = "",
     limit: int = 20,
+    offset: int = 0,
 ) -> dict[str, Any]:
     """Recherche plein texte dans la jurisprudence judiciaire, exécutée
     localement et affranchie de toute obligation d'authentification
     gouvernementale.
 
-    Exploite l'index FTS5 des archives publiques DILA (~620 000 décisions :
+    Exploite l'index FTS5 des archives publiques DILA (~1,17 M décisions :
     Cour de cassation, 36 cours d'appel, Conseil constitutionnel). Scoring
     BM25 disponible mais tri appliqué par ordre chronologique décroissant.
 
@@ -719,24 +772,36 @@ async def search_judiciaire_libre(
             qui matche toutes les variantes typographiques.
         date_min: date min ISO (YYYY-MM-DD), optionnel
         date_max: date max ISO (YYYY-MM-DD), optionnel
-        limit: nombre maximum de résultats (défaut 20)
+        limit: nombre maximum de résultats (défaut 20, max 50)
+        offset: décalage pour paginer (défaut 0). Si la réponse contient
+            `truncated: true`, réitérer avec `next_offset` pour la suite.
     """
     _record_call("search_judiciaire_libre")
-    return dila.search(
+    if not query.strip() and not numero_rg.strip():
+        return _tool_error(
+            "Fournir query (mots-clés FTS5) ou numero_rg.",
+            category="validation",
+        )
+    offset = max(0, int(offset))
+    # SQLite synchrone → thread dédié pour ne pas bloquer l'event loop
+    result = await asyncio.to_thread(
+        dila.search,
         query=query,
         juridiction=juridiction or None,
         numero_rg=numero_rg or None,
         date_min=date_min or None,
         date_max=date_max or None,
         limit=limit,
+        offset=offset,
     )
+    return _annotate_pagination(result, limit, offset, "decisions")
 
 
 @mcp.tool(annotations=ToolAnnotations(
     title="Texte intégral d'une décision judiciaire (DILA)", readOnlyHint=True))
 async def get_decision_judiciaire_libre(
     decision_id: str,
-) -> dict[str, Any] | None:
+) -> dict[str, Any]:
     """Extraction du texte intégral d'une décision judiciaire depuis l'index
     indépendant (sans authentification).
 
@@ -756,11 +821,21 @@ async def get_decision_judiciaire_libre(
     if cached is not None:
         return cached
     if decision_id.startswith(("DCE_", "DTA_", "DCAA_")) or decision_id.startswith("/Ariane_Web/"):
-        return {"error": (
+        return _tool_error(
             f"L'identifiant fourni ({decision_id!r}) relève de l'ordre administratif. "
-            "Recourir à `get_decision_text(decision_id)` en remplacement."
-        )}
-    result = dila.get_decision(decision_id)
+            "Recourir à `get_decision_text(decision_id)` en remplacement.",
+            category="validation",
+        )
+    result = await asyncio.to_thread(dila.get_decision, decision_id)
+    if result is None:
+        return _tool_error(
+            f"Décision {decision_id!r} introuvable dans l'archive DILA "
+            "locale. La base ne contient qu'un sous-ensemble des arrêts "
+            "publiés : vérifier l'identifiant via `search_judiciaire_libre`, "
+            "ou tenter `get_decision_judiciaire` (API PISTE) si la décision "
+            "est récente.",
+            category="not_found",
+        )
     _dec_cache_put(f"judi:{decision_id}", result)
     return result
 
@@ -768,15 +843,44 @@ async def get_decision_judiciaire_libre(
 # ─── JUSTICE JUDICIAIRE - BYOK PISTE OAuth2 ──────────────────────
 
 _NO_CREDS_MSG = (
-    "L'accès via PISTE requiert des identifiants OAuth2 (gratuits). "
+    "L'accès via PISTE requiert une authentification OAuth2 (gratuite). "
     "Dans la majorité des cas, privilégier `search_judiciaire_libre` ou "
     "`get_decision_judiciaire_libre`, qui interrogent l'archive locale "
-    "DILA (~620 000 décisions, sans authentification). Ne recourir à "
+    "DILA (~1,17 M décisions, sans authentification). Ne recourir à "
     "l'API PISTE qu'en cas de besoin avéré des toutes dernières décisions "
-    "non encore archivées. Obtenir un Client ID et un Client Secret PISTE "
-    "via https://justicelibre.org/tutoriel-piste.html, puis les transmettre "
-    "en paramètres."
+    "non encore archivées. Deux méthodes : 1) obtenir un session token "
+    "temporaire sur https://justicelibre.org/tutoriel-piste.html et le "
+    "passer en `session_token` ; 2) en auto-hébergement, définir les "
+    "variables d'environnement PISTE_CLIENT_ID / PISTE_CLIENT_SECRET côté "
+    "serveur. Ne JAMAIS transmettre un Client Secret PISTE dans la "
+    "conversation."
 )
+
+
+def _piste_http_error(e: httpx.HTTPStatusError) -> dict[str, Any]:
+    """Traduit une erreur HTTP PISTE en erreur structurée actionnable."""
+    code = e.response.status_code
+    if code in (401, 403):
+        return _tool_error(
+            f"Jeton PISTE expiré ou invalide (HTTP {code}). Régénérer un "
+            "session token, ou vérifier les variables d'environnement "
+            "PISTE_CLIENT_ID / PISTE_CLIENT_SECRET en auto-hébergement.",
+            category="auth",
+            regenerate_token_url="https://justicelibre.org/tutoriel-piste.html",
+        )
+    if code == 429:
+        return _tool_error(
+            "Rate-limit PISTE atteint (HTTP 429). Retenter après quelques "
+            "secondes, ou basculer sur `search_judiciaire_libre` (archive "
+            "locale, sans quota).",
+            category="upstream", retryable=True,
+        )
+    return _tool_error(
+        f"L'API PISTE a renvoyé HTTP {code}. Basculer sur "
+        "`search_judiciaire_libre` / `get_decision_judiciaire_libre` "
+        "(archive locale DILA) si la décision a plus de ~2 ans.",
+        category="upstream",
+    )
 
 
 @mcp.tool(annotations=ToolAnnotations(
@@ -784,8 +888,6 @@ _NO_CREDS_MSG = (
 async def search_judiciaire(
     query: str,
     session_token: str = "",
-    client_id: str = "",
-    client_secret: str = "",
     juridiction: str = "",
     limit: int = 20,
 ) -> dict[str, Any]:
@@ -797,19 +899,17 @@ async def search_judiciaire(
     décisions récentes absentes de la base libre DILA, compte tenu de
     l'entrave technique imposée par la Cour de cassation.
 
-    Deux méthodes d'authentification disponibles :
+    Authentification (les identifiants PISTE ne transitent JAMAIS par la
+    conversation) :
     1. `session_token` : jeton temporaire obtenu sur
-       justicelibre.org/tutoriel-piste.html (procédé recommandé, préserve
-       la confidentialité des identifiants).
-    2. `client_id` + `client_secret` : identifiants PISTE directs
-       (transmission en chat déconseillée).
+       justicelibre.org/tutoriel-piste.html (procédé recommandé).
+    2. Auto-hébergement : variables d'environnement PISTE_CLIENT_ID et
+       PISTE_CLIENT_SECRET définies côté serveur.
 
     Args:
         query: mots-clés de recherche
         session_token: jeton justicelibre temporaire (obtenu via le
             formulaire du site)
-        client_id: Client ID PISTE (alternative au session_token)
-        client_secret: Client Secret PISTE (alternative au session_token)
         juridiction: filtre optionnel — "cc" (Cour de cassation), "ca"
             (cours d'appel), "tj" (tribunaux judiciaires), "tcom"
             (tribunaux de commerce). Vide = toutes juridictions.
@@ -821,6 +921,8 @@ async def search_judiciaire(
         if not bearer:
             return {
                 "error": "Jeton de session expiré ou invalide.",
+                "error_category": "auth",
+                "retryable": False,
                 "fallback": "Si la décision recherchée a plus de ~2 ans, utiliser `search_judiciaire_libre` (base DILA locale, sans authentification) avant de tenter de régénérer un token.",
                 "regenerate_token_url": "https://justicelibre.org/tutoriel-piste.html",
             }
@@ -830,8 +932,17 @@ async def search_judiciaire(
             params: dict[str, Any] = {"query": query, "page_size": min(int(limit), 50)}
             if juridiction and juridiction in judilibre.JURIDICTIONS:
                 params["jurisdiction"] = juridiction
-            r = await client.get(f"{judilibre.BASE}/search", headers=headers, params=params)
-            r.raise_for_status()
+            try:
+                r = await client.get(f"{judilibre.BASE}/search", headers=headers, params=params)
+                r.raise_for_status()
+            except httpx.HTTPStatusError as e:
+                return _piste_http_error(e)
+            except httpx.HTTPError as e:
+                return _tool_error(
+                    f"Erreur réseau vers l'API PISTE : {e}. Retenter, ou "
+                    "basculer sur `search_judiciaire_libre` (archive locale).",
+                    category="upstream", retryable=True,
+                )
             data = r.json()
             results = data.get("results", [])
             return {
@@ -840,17 +951,26 @@ async def search_judiciaire(
                 "decisions": [judilibre._normalize_decision(d) for d in results],
             }
 
-    # Method 2: direct credentials (fallback)
-    cid = client_id or os.environ.get("PISTE_CLIENT_ID", "")
-    csec = client_secret or os.environ.get("PISTE_CLIENT_SECRET", "")
+    # Method 2: credentials serveur (env vars, auto-hébergement uniquement)
+    cid = os.environ.get("PISTE_CLIENT_ID", "")
+    csec = os.environ.get("PISTE_CLIENT_SECRET", "")
     if not cid or not csec:
-        return {"error": _NO_CREDS_MSG}
+        return _tool_error(_NO_CREDS_MSG, category="auth")
     _record_call("search_judiciaire")
     async with _client() as client:
-        return await judilibre.search(
-            client, client_id=cid, client_secret=csec, query=query,
-            juridiction=juridiction or None, limit=limit,
-        )
+        try:
+            return await judilibre.search(
+                client, client_id=cid, client_secret=csec, query=query,
+                juridiction=juridiction or None, limit=limit,
+            )
+        except httpx.HTTPStatusError as e:
+            return _piste_http_error(e)
+        except httpx.HTTPError as e:
+            return _tool_error(
+                f"Erreur réseau vers l'API PISTE : {e}. Retenter, ou "
+                "basculer sur `search_judiciaire_libre` (archive locale).",
+                category="upstream", retryable=True,
+            )
 
 
 @mcp.tool(annotations=ToolAnnotations(
@@ -858,9 +978,7 @@ async def search_judiciaire(
 async def get_decision_judiciaire(
     decision_id: str,
     session_token: str = "",
-    client_id: str = "",
-    client_secret: str = "",
-) -> dict[str, Any] | None:
+) -> dict[str, Any]:
     """Extraction du texte intégral d'une décision judiciaire via l'API
     restreinte PISTE (authentification OAuth2 requise).
 
@@ -870,44 +988,84 @@ async def get_decision_judiciaire(
     Outil formellement inopérant pour les décisions relevant de l'ordre
     administratif (formats `DCE_*`, `DTA_*`, `DCAA_*`, `/Ariane_Web/...`).
 
+    Authentification (les identifiants PISTE ne transitent JAMAIS par la
+    conversation) : `session_token` obtenu sur
+    justicelibre.org/tutoriel-piste.html, ou variables d'environnement
+    PISTE_CLIENT_ID / PISTE_CLIENT_SECRET côté serveur (auto-hébergement).
+
     Args:
         decision_id: identifiant Judilibre de la décision
         session_token: jeton justicelibre temporaire (recommandé)
-        client_id: Client ID PISTE (alternative)
-        client_secret: Client Secret PISTE (alternative)
     """
     if decision_id.startswith(("DCE_", "DTA_", "DCAA_")) or decision_id.startswith("/Ariane_Web/"):
-        return {"error": (
+        return _tool_error(
             f"L'identifiant fourni ({decision_id!r}) relève de l'ordre administratif. "
-            "Recourir à `get_decision_text(decision_id)` en remplacement."
-        )}
+            "Recourir à `get_decision_text(decision_id)` en remplacement.",
+            category="validation",
+        )
+    _not_found = _tool_error(
+        f"Décision {decision_id!r} introuvable via l'API PISTE. Vérifier "
+        "l'identifiant via `search_judiciaire`, ou tenter "
+        "`get_decision_judiciaire_libre` si la décision figure dans les "
+        "archives DILA.",
+        category="not_found",
+    )
     # Method 1: session token
     if session_token:
         bearer = _resolve_session(session_token)
         if not bearer:
             return {
                 "error": "Jeton de session expiré ou invalide.",
+                "error_category": "auth",
+                "retryable": False,
                 "fallback": "Tenter `get_decision_judiciaire_libre` avec le même ID si la décision existe dans les archives DILA.",
                 "regenerate_token_url": "https://justicelibre.org/tutoriel-piste.html",
             }
         _record_call("get_decision_judiciaire")
         async with _client() as client:
             headers = {"Authorization": f"Bearer {bearer}"}
-            r = await client.get(f"{judilibre.BASE}/decision", headers=headers, params={"id": decision_id})
-            r.raise_for_status()
+            try:
+                r = await client.get(f"{judilibre.BASE}/decision", headers=headers, params={"id": decision_id})
+                r.raise_for_status()
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code == 404:
+                    return _not_found
+                return _piste_http_error(e)
+            except httpx.HTTPError as e:
+                return _tool_error(
+                    f"Erreur réseau vers l'API PISTE : {e}. Retenter, ou "
+                    "basculer sur `get_decision_judiciaire_libre`.",
+                    category="upstream", retryable=True,
+                )
             data = r.json()
             if not data:
-                return None
+                return _not_found
             return judilibre._normalize_decision(data)
 
-    # Method 2: direct credentials
-    cid = client_id or os.environ.get("PISTE_CLIENT_ID", "")
-    csec = client_secret or os.environ.get("PISTE_CLIENT_SECRET", "")
+    # Method 2: credentials serveur (env vars, auto-hébergement uniquement)
+    cid = os.environ.get("PISTE_CLIENT_ID", "")
+    csec = os.environ.get("PISTE_CLIENT_SECRET", "")
     if not cid or not csec:
-        return {"error": _NO_CREDS_MSG}
+        return _tool_error(_NO_CREDS_MSG, category="auth")
     _record_call("get_decision_judiciaire")
     async with _client() as client:
-        return await judilibre.get_decision(client, client_id=cid, client_secret=csec, decision_id=decision_id)
+        try:
+            result = await judilibre.get_decision(
+                client, client_id=cid, client_secret=csec, decision_id=decision_id
+            )
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                return _not_found
+            return _piste_http_error(e)
+        except httpx.HTTPError as e:
+            return _tool_error(
+                f"Erreur réseau vers l'API PISTE : {e}. Retenter, ou "
+                "basculer sur `get_decision_judiciaire_libre`.",
+                category="upstream", retryable=True,
+            )
+    if result is None:
+        return _not_found
+    return result
 
 
 # ─── COURS EUROPÉENNES (CJUE + CEDH) — index local, sans auth ────
@@ -919,7 +1077,7 @@ async def resolve_law_number(numero: str) -> dict[str, Any]:
     ou JORFTEXT Légifrance.
 
     Utile pour les textes non codifiés (lois, ordonnances, décrets) qui ne
-    sont pas dans la whitelist des 25 codes courts (CC, CP, LIL, LO58, etc.).
+    sont pas dans la whitelist des 26 codes courts (CC, CP, LIL, LO58, etc.).
     Une fois le LEGITEXT/JORFTEXT résolu, on peut l'utiliser avec
     `get_law_article(code=<LEGITEXT>, num=<N>)` pour récupérer un article
     spécifique.
@@ -975,17 +1133,23 @@ async def build_source_url(identifier: str, legitext: str = "", date: str = "") 
     """
     _record_call("build_source_url")
     if not identifier.strip():
-        return {"error": "identifier requis"}
+        return _tool_error("identifier requis", category="validation")
     from sources import warehouse as wh
     url = await wh.build_url(identifier, legitext or None, date or None)
     if not url:
-        return {"error": f"format d'identifiant non reconnu : {identifier!r}"}
+        return _tool_error(
+            f"format d'identifiant non reconnu : {identifier!r}. Formats "
+            "acceptés : LEGIARTI*, LEGITEXT*, JORFTEXT*, JURITEXT*, "
+            "CONSTEXT*, CETATEXT*, CELEX, ECLI:*, itemid HUDOC (001-*), "
+            "ArianeWeb.",
+            category="validation",
+        )
     return {"id": identifier, "source_url": url}
 
 
 @mcp.tool(annotations=ToolAnnotations(
     title="Décision du Conseil constitutionnel par numéro", readOnlyHint=True))
-async def get_cc_decision(numero: str, nature: str = "") -> dict[str, Any] | None:
+async def get_cc_decision(numero: str, nature: str = "") -> dict[str, Any]:
     """Récupère une décision du Conseil constitutionnel par son numéro.
 
     Format attendu : "AA-NNN NATURE" ou juste "AA-NNN" (ex : "79-105 DC",
@@ -997,15 +1161,25 @@ async def get_cc_decision(numero: str, nature: str = "") -> dict[str, Any] | Non
         nature: filtre optionnel (QPC, DC, L, etc.) — cf search_cc
 
     Returns:
-        `{id, titre, date, juridiction, nature, ecli, text}` ou None.
+        `{id, titre, date, juridiction, nature, ecli, text}`, ou dict
+        d'erreur structuré `{error, error_category: "not_found"}` si
+        introuvable.
     """
     _record_call("get_cc_decision")
-    return dila.get_cc_decision(numero, nature or None)
+    result = await asyncio.to_thread(dila.get_cc_decision, numero, nature or None)
+    if result is None:
+        return _tool_error(
+            f"Décision du Conseil constitutionnel {numero!r} introuvable. "
+            "Vérifier le format du numéro ('AA-NNN' ou 'AA-NNN DC', ex : "
+            "'79-105 DC') ou chercher par mots-clés via `search_cc`.",
+            category="not_found",
+        )
+    return result
 
 
 @mcp.tool(annotations=ToolAnnotations(
     title="Décision du Conseil d'État par numéro", readOnlyHint=True))
-async def get_ce_decision(numero: str) -> dict[str, Any] | None:
+async def get_ce_decision(numero: str) -> dict[str, Any]:
     """Récupère une décision du Conseil d'État par son numéro de pourvoi.
 
     Essaie d'abord le bulk JADE DILA (lookup SQL exact), puis si introuvable
@@ -1018,10 +1192,21 @@ async def get_ce_decision(numero: str) -> dict[str, Any] | None:
         numero: numéro de pourvoi (ex : "497566", "358109")
 
     Returns:
-        Décision avec métadonnées, ou None si introuvable dans les deux bases.
+        Décision avec métadonnées, ou dict d'erreur structuré
+        `{error, error_category: "not_found"}` si introuvable dans les
+        deux bases.
     """
     _record_call("get_ce_decision")
-    return await jade_remote.get_ce_decision(numero)
+    result = await jade_remote.get_ce_decision(numero)
+    if result is None:
+        return _tool_error(
+            f"Décision CE n° {numero} introuvable (bulk JADE + ArianeWeb). "
+            "Essayer `search_admin(query=numero)` (recherche full text), ou "
+            "`get_decision_text` si l'identifiant Légifrance CETATEXT est "
+            "connu.",
+            category="not_found",
+        )
+    return result
 
 
 @mcp.tool(annotations=ToolAnnotations(
@@ -1066,8 +1251,11 @@ async def get_admin_decision(numero: str, juridiction: str = "") -> dict[str, An
     _record_call("get_admin_decision")
     result = await jade_remote.get_admin_decision(numero, juridiction or None)
     if result is None:
-        return {"error": f"Décision n° {numero} introuvable dans JADE (bulk DILA). "
-                         f"Si la décision est récente (< 3 mois), essayer `search_admin_recent`."}
+        return _tool_error(
+            f"Décision n° {numero} introuvable dans JADE (bulk DILA). "
+            "Si la décision est récente (< 3 mois), essayer `search_admin_recent`.",
+            category="not_found",
+        )
     return result
 
 
@@ -1112,18 +1300,26 @@ async def search_cc(
         `{"total", "returned", "nature_filter", "decisions": [...]}`
     """
     _record_call("search_cc")
-    return dila.search_cc(
+    if not query.strip():
+        return _tool_error(
+            "Le paramètre query est requis (mots-clés FTS5, ex : "
+            "\"proportionnalité\").",
+            category="validation",
+        )
+    result = await asyncio.to_thread(
+        dila.search_cc,
         query=query,
         nature=nature or None,
         date_min=date_min or None,
         date_max=date_max or None,
         limit=limit, offset=offset,
     )
+    return _annotate_pagination(result, limit, offset, "decisions")
 
 
 @mcp.tool(annotations=ToolAnnotations(
     title="Recherche Cour EDH", readOnlyHint=True))
-async def search_cedh(query: str, limit: int = 20) -> dict[str, Any]:
+async def search_cedh(query: str, limit: int = 20, offset: int = 0) -> dict[str, Any]:
     """Recherche textuelle dans la jurisprudence de la Cour européenne des
     droits de l'homme.
 
@@ -1133,28 +1329,52 @@ async def search_cedh(query: str, limit: int = 20) -> dict[str, Any]:
 
     Args:
         query: mots-clés (ex : "article 8 vie familiale", "garde à vue")
-        limit: nombre maximum de résultats (défaut 20)
+        limit: nombre maximum de résultats (défaut 20, max 50)
+        offset: décalage pour paginer (défaut 0). Si la réponse contient
+            `truncated: true`, réitérer avec `next_offset` pour la suite.
     """
     _record_call("search_cedh")
-    return european.search_cedh(query=query, limit=limit)
+    if not query.strip():
+        return _tool_error(
+            "Le paramètre query est requis (mots-clés, ex : \"article 8 "
+            "vie familiale\").",
+            category="validation",
+        )
+    offset = max(0, int(offset))
+    result = await asyncio.to_thread(
+        european.search_cedh, query=query, limit=limit, offset=offset
+    )
+    return _annotate_pagination(result, limit, offset, "decisions")
 
 
 @mcp.tool(annotations=ToolAnnotations(
     title="Texte intégral d'une décision CEDH", readOnlyHint=True))
-async def get_decision_cedh(decision_id: str) -> dict[str, Any] | None:
+async def get_decision_cedh(decision_id: str) -> dict[str, Any]:
     """Extraction du texte intégral d'une décision de la Cour européenne des
     droits de l'homme sur la base de son identifiant système (itemid HUDOC).
 
     Args:
         decision_id: itemid HUDOC (ex : "001-249914")
+
+    Returns:
+        Décision avec `full_text`, ou dict d'erreur structuré
+        `{error, error_category: "not_found"}` si l'itemid est inconnu.
     """
     _record_call("get_decision_cedh")
-    return european.get_cedh(decision_id)
+    result = await asyncio.to_thread(european.get_cedh, decision_id)
+    if result is None:
+        return _tool_error(
+            f"Itemid HUDOC {decision_id!r} introuvable dans l'index CEDH "
+            "local. Vérifier l'identifiant (format 001-XXXXXX) via "
+            "`search_cedh`.",
+            category="not_found",
+        )
+    return result
 
 
 @mcp.tool(annotations=ToolAnnotations(
     title="Recherche CJUE", readOnlyHint=True))
-async def search_cjue(query: str, limit: int = 20) -> dict[str, Any]:
+async def search_cjue(query: str, limit: int = 20, offset: int = 0) -> dict[str, Any]:
     """Recherche textuelle dans la jurisprudence de la Cour de justice de
     l'Union européenne.
 
@@ -1164,28 +1384,56 @@ async def search_cjue(query: str, limit: int = 20) -> dict[str, Any]:
 
     Args:
         query: mots-clés (ex : "libre circulation capitaux", "CJUE C-72/24")
-        limit: nombre maximum de résultats (défaut 20)
+        limit: nombre maximum de résultats (défaut 20, max 50)
+        offset: décalage pour paginer (défaut 0). Si la réponse contient
+            `truncated: true`, réitérer avec `next_offset` pour la suite.
     """
     _record_call("search_cjue")
-    return european.search_cjue(query=query, limit=limit)
+    if not query.strip():
+        return _tool_error(
+            "Le paramètre query est requis (mots-clés, ex : \"libre "
+            "circulation capitaux\").",
+            category="validation",
+        )
+    offset = max(0, int(offset))
+    result = await asyncio.to_thread(
+        european.search_cjue, query=query, limit=limit, offset=offset
+    )
+    return _annotate_pagination(result, limit, offset, "decisions")
 
 
 @mcp.tool(annotations=ToolAnnotations(
     title="Texte intégral d'un arrêt CJUE", readOnlyHint=True))
-async def get_decision_cjue(decision_id: str) -> dict[str, Any] | None:
+async def get_decision_cjue(decision_id: str) -> dict[str, Any]:
     """Extraction du texte intégral d'une décision de la Cour de justice de
     l'Union européenne sur la base de son identifiant normalisé (CELEX).
 
+    Seuls les identifiants CELEX sont acceptés — un ECLI seul ne suffit
+    pas : retrouver d'abord le CELEX correspondant via `search_cjue`.
+
     Args:
-        decision_id: identifiant CELEX (ex : "62024CJ0072") ou ECLI
+        decision_id: identifiant CELEX (ex : "62024CJ0072")
+
+    Returns:
+        Décision avec `full_text`, ou dict d'erreur structuré
+        `{error, error_category: "not_found"}` si le CELEX est inconnu.
     """
     _record_call("get_decision_cjue")
-    return european.get_cjue(decision_id)
+    result = await asyncio.to_thread(european.get_cjue, decision_id)
+    if result is None:
+        return _tool_error(
+            f"Identifiant {decision_id!r} introuvable dans l'index CJUE "
+            "local. Seuls les CELEX sont acceptés (ex : '62024CJ0072') — "
+            "pour un ECLI ou un n° d'affaire (C-72/24), retrouver le CELEX "
+            "via `search_cjue`.",
+            category="not_found",
+        )
+    return result
 
 
 # ─── BULKS DILA — RECHERCHE BM25 SUR ARCHIVES COMPLÈTES ────────────
 # Ces outils exploitent les bulks DILA ingérés en local sur al-uzza :
-# jade (4M décisions admin), legi (codes+lois consolidés), jorf (JO
+# jade (~550 k décisions admin), legi (codes+lois consolidés), jorf (JO
 # post-1990), kali (conventions collectives), cnil (délibérations).
 # Tous avec ranking BM25 (vraie pertinence) + snippet + date range.
 # Différence-clé avec les tools `*_recent` : tri par pertinence, pas
@@ -1233,11 +1481,12 @@ async def search_admin(
         {"total", "returned", "decisions": [...]} avec extracts BM25.
     """
     _record_call("search_admin")
-    return await jade_remote.search(
+    result = await jade_remote.search(
         query=query, juridiction=juridiction or None, sort=sort,
         date_min=date_min or None, date_max=date_max or None,
         limit=limit, offset=offset,
     )
+    return _annotate_pagination(result, limit, offset, "decisions")
 
 
 @mcp.tool(annotations=ToolAnnotations(
@@ -1272,7 +1521,7 @@ async def search_legi(
         date_min=date_min or None, date_max=date_max or None,
         code=code or None,
     )
-    return {
+    result = {
         "total": data.get("total", 0),
         "returned": data.get("returned", 0),
         "limit": limit, "offset": offset,
@@ -1289,6 +1538,7 @@ async def search_legi(
             for h in data.get("results", [])
         ],
     }
+    return _annotate_pagination(result, limit, offset, "articles")
 
 
 @mcp.tool(annotations=ToolAnnotations(
@@ -1316,11 +1566,12 @@ async def search_jorf(
         {"total", "returned", "textes": [...]}
     """
     _record_call("search_jorf")
-    return await jorf_remote.search(
+    result = await jorf_remote.search(
         query=query, nature=nature or None,
         date_min=date_min or None, date_max=date_max or None,
         limit=limit, offset=offset,
     )
+    return _annotate_pagination(result, limit, offset, "textes")
 
 
 @mcp.tool(annotations=ToolAnnotations(
@@ -1343,10 +1594,11 @@ async def search_kali(
         limit: max 50
     """
     _record_call("search_kali")
-    return await kali_remote.search(
+    result = await kali_remote.search(
         query=query, idcc=idcc or None,
         limit=limit, offset=offset,
     )
+    return _annotate_pagination(result, limit, offset, "textes")
 
 
 @mcp.tool(annotations=ToolAnnotations(
@@ -1358,11 +1610,12 @@ async def search_cnil(
 ) -> dict[str, Any]:
     """Recherche dans les délibérations de la CNIL.
 
-    Source : bulk CNIL (109 Mo, ~26k délibérations). Utile pour le droit
+    Source : bulk CNIL (109 Mo, ~8 000 délibérations). Utile pour le droit
     des données personnelles, RGPD, traitements algorithmiques.
     """
     _record_call("search_cnil")
-    return await cnil_remote.search(query=query, limit=limit, offset=offset)
+    result = await cnil_remote.search(query=query, limit=limit, offset=offset)
+    return _annotate_pagination(result, limit, offset, "deliberations")
 
 
 # ─── ARTICLES DE LOI (codes consolidés, versions historiques) ───────
@@ -1383,9 +1636,10 @@ async def get_law_article(code: str, num: str, date: str = "") -> dict[str, Any]
     2016. Avec ce tool on récupère le texte **tel qu'il existait en 1992**
     (l'ancienne version napoléonienne), pas le texte actuel.
 
-    Codes supportés (22) : CC, CP, CPC, CPP, CT, CSP, CJA, CGCT, CRPA,
-    CPI, CASF, CMF, C.com, C.cons, C.éduc, CU, C.env, CR, CGI, CESEDA,
-    CSS, CCH.
+    Codes/textes supportés (26) : 22 codes consolidés — CC, CP, CPC, CPP,
+    CT, CSP, CJA, CGCT, CRPA, CPI, CASF, CMF, C.com, C.cons, C.éduc, CU,
+    C.env, CR, CGI, CESEDA, CSS, CCH — + 4 textes non codifiés : CONST
+    (Constitution), LIL, LO58, L2005-102.
 
     Args:
         code: code court (ex : "CC" pour Code civil, "CT" pour Code du travail)
@@ -1418,7 +1672,8 @@ async def get_law_versions(code: str, num: str) -> dict[str, Any]:
     avec `date_debut`, `date_fin`, `etat`, `texte` distincts).
 
     Args:
-        code: code court (voir get_law_article pour la liste des 22 codes)
+        code: code court (voir get_law_article pour la liste des 26
+            codes/textes)
         num: numéro de l'article
 
     Returns:
@@ -1466,12 +1721,17 @@ async def search_decisions_citing(
 
     Returns:
         dict `{"code", "num", "total", "per_source": {source: count},
-        "decisions": [{source, id, juridiction, date, title, extract}]}`
+        "decisions": [{source, id, juridiction, date, title, extract}]}`.
+        Si une source est en panne, elle est absente de `per_source` et
+        détaillée dans `source_errors` (résultats alors incomplets).
     """
     _record_call("search_decisions_citing")
     if not legi.is_supported(code):
-        return {"error": f"Code inconnu: {code!r}",
-                "supported_codes": list(legi.SUPPORTED_CODES.keys())}
+        return _tool_error(
+            f"Code inconnu: {code!r}",
+            category="validation",
+            supported_codes=list(legi.SUPPORTED_CODES.keys()),
+        )
     code_long = legi.SUPPORTED_CODES[code]
     limit = max(1, min(int(limit), 50))
     # Construire une query FTS5 couvrant les formulations habituelles.
@@ -1486,10 +1746,23 @@ async def search_decisions_citing(
     allowed = set(sources) if sources else {"dila", "jade", "cedh", "cjue"}
     results = []
     per_source: dict[str, int] = {}
+    # Pannes séparées des comptages : per_source ne contient QUE des int,
+    # les erreurs vont dans source_errors (structuré, retryable).
+    source_errors: dict[str, dict[str, Any]] = {}
+
+    def _record_error(src: str, e: Exception) -> None:
+        source_errors[src] = {
+            "error": f"Source {src} en échec : {e}",
+            "error_category": "upstream",
+            "retryable": True,
+        }
+
     # DILA (local FTS5)
     if "dila" in allowed:
         try:
-            d = dila.search(query=query, juridiction="", limit=limit)
+            d = await asyncio.to_thread(
+                dila.search, query=query, juridiction="", limit=limit
+            )
             for h in d.get("decisions", []):
                 results.append({
                     "source": "dila", "id": h.get("id"),
@@ -1499,7 +1772,7 @@ async def search_decisions_citing(
                 })
             per_source["dila"] = d.get("total", 0)
         except Exception as e:
-            per_source["dila"] = f"error: {e}"
+            _record_error("dila", e)
     # JADE (via warehouse)
     if "jade" in allowed:
         try:
@@ -1514,11 +1787,13 @@ async def search_decisions_citing(
                 })
             per_source["jade"] = d.get("total", 0)
         except Exception as e:
-            per_source["jade"] = f"error: {e}"
+            _record_error("jade", e)
     # CEDH
     if "cedh" in allowed:
         try:
-            d = european.search_cedh(query=query, limit=limit)
+            d = await asyncio.to_thread(
+                european.search_cedh, query=query, limit=limit
+            )
             for h in d.get("decisions", []):
                 results.append({
                     "source": "cedh", "id": h.get("id"),
@@ -1528,11 +1803,13 @@ async def search_decisions_citing(
                 })
             per_source["cedh"] = d.get("total", 0)
         except Exception as e:
-            per_source["cedh"] = f"error: {e}"
+            _record_error("cedh", e)
     # CJUE
     if "cjue" in allowed:
         try:
-            d = european.search_cjue(query=query, limit=limit)
+            d = await asyncio.to_thread(
+                european.search_cjue, query=query, limit=limit
+            )
             for h in d.get("decisions", []):
                 results.append({
                     "source": "cjue", "id": h.get("id"),
@@ -1542,14 +1819,22 @@ async def search_decisions_citing(
                 })
             per_source["cjue"] = d.get("total", 0)
         except Exception as e:
-            per_source["cjue"] = f"error: {e}"
-    return {
+            _record_error("cjue", e)
+    out = {
         "code": code, "num": num,
         "query_built": query,
         "total": len(results),
         "per_source": per_source,
         "decisions": results[:limit * len(allowed)],
     }
+    if source_errors:
+        out["source_errors"] = source_errors
+        out["warning"] = (
+            f"{len(source_errors)} source(s) en échec — résultats "
+            "potentiellement incomplets, retenter ou interroger la source "
+            "directement."
+        )
+    return out
 
 
 # ─── TOOL UNIFIÉ : search_all ──────────────────────────────────────
@@ -1581,11 +1866,16 @@ async def search_all(
             "cjue"]. None = toutes.
         sort: "relevance" (défaut) ou "date_desc"
         date_min, date_max: ISO YYYY-MM-DD
-        limit: nombre de résultats fusionnés (défaut 30, max 100)
+        limit: nombre de résultats fusionnés (défaut 30, max 100 ; chaque
+            source locale plafonne à 50 résultats par appel)
         expand_synonyms: active le thésaurus (défaut True)
 
     Returns:
-        dict {"query_expanded", "per_source_counts", "results": [...]}
+        dict {"query_expanded", "per_source_counts", "results": [...]}.
+        `per_source_counts` ne compte que les sources ayant répondu ; si
+        une source est en panne, elle est détaillée dans `source_errors`
+        et un `warning` signale des résultats potentiellement incomplets.
+        `truncated: true` + `note` signalent que la fusion dépasse `limit`.
     """
     _record_call("search_all")
     limit = max(1, min(int(limit), 100))
@@ -1606,13 +1896,19 @@ async def search_all(
         "legi": 0.80,  # articles de loi (pertinents mais on veut des décisions)
     }
 
-    import asyncio
+    async def _run(q: str) -> tuple[dict[str, int], list[dict], dict[str, dict]]:
+        # Pannes visibles : une source en échec ne doit PAS apparaître comme
+        # "0 résultat" (le modèle conclurait à tort qu'il n'y a pas de
+        # jurisprudence). errors est partagé, _search_one retourne None
+        # comme total en cas d'échec.
+        errors: dict[str, dict[str, Any]] = {}
 
-    async def _run(q: str) -> tuple[dict[str, int], list[dict]]:
         async def _search_one(src: str):
             try:
                 if src == "dila":
-                    d = dila.search(query=q, juridiction="", limit=limit)
+                    # SQLite synchrone → thread pour ne pas bloquer l'event loop
+                    d = await asyncio.to_thread(
+                        dila.search, query=q, juridiction="", limit=limit)
                     hits = [{"source": "dila", "id": h.get("id"),
                              "juridiction": h.get("juridiction"),
                              "date": h.get("date"), "title": h.get("title"),
@@ -1639,7 +1935,8 @@ async def search_all(
                              "score": 1.0} for h in d.get("results", [])]
                     return src, d.get("total", 0), hits
                 if src == "cedh":
-                    d = european.search_cedh(query=q, limit=limit)
+                    d = await asyncio.to_thread(
+                        european.search_cedh, query=q, limit=limit)
                     hits = [{"source": "cedh", "id": h.get("id"),
                              "juridiction": "Cour EDH",
                              "date": h.get("date"), "title": h.get("title"),
@@ -1647,7 +1944,8 @@ async def search_all(
                              "score": 1.0} for h in d.get("decisions", [])]
                     return src, d.get("total", 0), hits
                 if src == "cjue":
-                    d = european.search_cjue(query=q, limit=limit)
+                    d = await asyncio.to_thread(
+                        european.search_cjue, query=q, limit=limit)
                     hits = [{"source": "cjue", "id": h.get("id"),
                              "juridiction": "CJUE",
                              "date": h.get("date"), "title": h.get("title"),
@@ -1655,7 +1953,12 @@ async def search_all(
                              "score": 1.0} for h in d.get("decisions", [])]
                     return src, d.get("total", 0), hits
             except Exception as e:
-                return src, 0, [{"source": src, "error": str(e)}]
+                errors[src] = {
+                    "error": f"Source {src} en échec : {e}",
+                    "error_category": "upstream",
+                    "retryable": True,
+                }
+                return src, None, []
             return src, 0, []
 
         tasks = [_search_one(s) for s in allowed]
@@ -1663,31 +1966,31 @@ async def search_all(
         ps: dict[str, int] = {}
         merged_local: list[dict] = []
         for src, total, hits in results_raw:
+            if total is None:
+                continue  # source en panne → détaillée dans errors
             ps[src] = total
             boost = AUTHORITY.get(src, 1.0)
             for rank, h in enumerate(hits):
-                if "error" in h:
-                    continue
                 # -rank*0.001 préserve l'ordre BM25 interne à chaque source : une
                 # décision classée avant une autre par sa source le reste à boost
                 # égal (évite qu'une décision citante passe devant la vraie).
                 h["score"] = h.get("score", 1.0) * boost - rank * 0.001
                 merged_local.append(h)
         merged_local.sort(key=lambda h: h.get("score", 0), reverse=True)
-        return ps, merged_local
+        return ps, merged_local, errors
 
     # 1er essai (avec expansion si demandée)
-    per_source, merged = await _run(q_expanded)
+    per_source, merged, source_errors = await _run(q_expanded)
     fallback_used = False
     # Fallback : si l'expansion thésaurus a tué tous les résultats (cas
     # fréquent quand la requête a beaucoup de termes libres, le AND implicite
     # FTS5 vide l'intersection), retomber sur la query nue. Évite de répondre
     # 0 résultats alors que la version sans expansion en aurait des dizaines.
     if not merged and q_expanded != query:
-        per_source, merged = await _run(query)
+        per_source, merged, source_errors = await _run(query)
         fallback_used = True
 
-    return {
+    out = {
         "query": query,
         "query_expanded": q_expanded if q_expanded != query else None,
         "fallback_no_expand": fallback_used,
@@ -1695,6 +1998,21 @@ async def search_all(
         "total_returned": len(merged[:limit]),
         "results": merged[:limit],
     }
+    if source_errors:
+        out["source_errors"] = source_errors
+        out["warning"] = (
+            f"{len(source_errors)} source(s) en échec — résultats "
+            "potentiellement incomplets, retenter ou interroger la source "
+            "directement."
+        )
+    if len(merged) > limit:
+        out["truncated"] = True
+        out["note"] = (
+            f"{len(merged)} résultats fusionnés, seuls les {limit} premiers "
+            "sont renvoyés — affiner la query ou augmenter `limit` "
+            "(max 100) pour en voir davantage."
+        )
+    return out
 
 
 if __name__ == "__main__":

--- a/sources/cnil_remote.py
+++ b/sources/cnil_remote.py
@@ -1,6 +1,6 @@
 """Wrapper MCP pour les délibérations CNIL.
 
-cnil.db contient les 26k+ délibérations de la Commission nationale de
+cnil.db contient les ~8 000 délibérations de la Commission nationale de
 l'informatique et des libertés (droit RGPD, données personnelles).
 """
 from __future__ import annotations

--- a/sources/dila.py
+++ b/sources/dila.py
@@ -28,7 +28,50 @@ def _sanitize_fts5(q: str) -> str:
     if not q:
         return ""
     # Caractères autorisés : alphanum, espaces, ", *, (, ), -, accents (\w + unicode)
-    return re.sub(r"[^\w\s\"*()\-]", " ", q, flags=re.UNICODE).strip()
+    q = re.sub(r"[^\w\s\"*()\-]", " ", q, flags=re.UNICODE)
+    # Guillemets non appariés : FTS5 lève SyntaxError sur une phrase non
+    # fermée — on retire alors tous les guillemets plutôt que de deviner
+    # où la phrase devait s'arrêter.
+    if q.count('"') % 2:
+        q = q.replace('"', " ")
+    # Parenthèses : FTS5 ne les accepte que dans des groupes booléens
+    # explicites (`(a OR b) AND c`) — un simple `mot (précision)` est une
+    # SyntaxError. On ne les conserve donc que si la query utilise des
+    # opérateurs booléens ET qu'elles sont équilibrées.
+    if not re.search(r"\b(AND|OR|NOT)\b", q) or q.count("(") != q.count(")"):
+        q = q.replace("(", " ").replace(")", " ")
+    # Hors phrase quotée, FTS5 parse `a-b` comme filtre de colonne et lève
+    # SyntaxError ("79-105", "garde-à-vue"). On quote donc les tokens à
+    # tiret, on retire les tirets isolés et les * non collés à un mot.
+    parts = q.split('"')
+    for i in range(0, len(parts), 2):  # segments hors guillemets uniquement
+        seg = re.sub(
+            r"(\w+(?:-\w+)+)(\*?)",
+            lambda m: f'"{m.group(1)}"{m.group(2)}',
+            parts[i], flags=re.UNICODE,
+        )
+        seg = re.sub(r"(?<!\w)-|-(?!\w)", " ", seg)
+        seg = re.sub(r'(?<![\w"])\*', " ", seg)
+        parts[i] = seg
+    out = '"'.join(parts).strip()
+    # Opérateur booléen orphelin en tête ou en queue ("harcèlement AND") :
+    # SyntaxError FTS5 — on le retire.
+    return re.sub(
+        r"^(?:\s*(?:AND|OR|NOT)\b)+|(?:\b(?:AND|OR|NOT)\s*)+$", " ", out
+    ).strip()
+
+def _fts_syntax_error_result(e: Exception) -> dict[str, Any]:
+    """Filet de sécurité : malgré _sanitize_fts5, FTS5 peut encore rejeter
+    une combinaison d'opérateurs (parenthèses déséquilibrées, NOT en tête…).
+    Retour 0-résultat actionnable plutôt qu'une exception opaque au modèle."""
+    return {
+        "total": 0,
+        "returned": 0,
+        "decisions": [],
+        "note": f"Syntaxe de recherche invalide pour FTS5 ({e}). Reformuler "
+                "en mots-clés simples, sans opérateurs ni ponctuation.",
+    }
+
 
 JURIDICTIONS = {
     "cassation": "Cour de cassation",
@@ -75,6 +118,7 @@ def search(
     limit: int = 20,
     offset: int = 0,
 ) -> dict[str, Any]:
+    limit = max(1, min(int(limit), 50))
     # Lookup direct par numero_rg si fourni : court-circuite FTS
     if numero_rg:
         canonical = _normalize_rg(numero_rg)
@@ -146,9 +190,20 @@ def search(
             from query_intent import normalize_fts_query
             fts_query = normalize_fts_query(query, expand=False)
         except Exception:
-            fts_query = _sanitize_fts5(query)
+            fts_query = query
+        # normalize_fts_query quote les tokens composés mais ne retire PAS les
+        # caractères qui font planter FTS5 en SyntaxError (`:`, `;`, apostrophes,
+        # points isolés…) — on passe donc systématiquement par _sanitize_fts5
+        # avant le MATCH, y compris sur le chemin normal.
+        fts_query = _sanitize_fts5(fts_query)
         if not fts_query:
-            return {"total": 0, "decisions": []}
+            return {
+                "total": 0,
+                "returned": 0,
+                "decisions": [],
+                "note": "Query vide après nettoyage FTS5 (caractères spéciaux "
+                        "retirés). Reformuler en mots-clés simples.",
+            }
 
         # snippet() : extrait autour du match, ~28 tokens, highlights <em>…</em>
         SNIPPET_SQL = "snippet(decisions_fts, -1, '<em>', '</em>', '…', 28)"
@@ -170,22 +225,25 @@ def search(
 
         # ORDER BY rank (BM25) quand on a une query — sinon date DESC
         # (rank est négatif, ASC = best score first)
-        rows = conn.execute(
-            f"""SELECT d.id, d.titre, d.date, d.juridiction, d.solution,
-                       d.numero, d.formation, d.ecli, d.nature,
-                       {SNIPPET_SQL} AS snip
-                FROM decisions_fts f
-                JOIN decisions d ON d.rowid = f.rowid
-                WHERE {where_sql}
-                ORDER BY rank
-                LIMIT ? OFFSET ?""",
-            params + [int(limit), int(offset)],
-        ).fetchall()
+        try:
+            rows = conn.execute(
+                f"""SELECT d.id, d.titre, d.date, d.juridiction, d.solution,
+                           d.numero, d.formation, d.ecli, d.nature,
+                           {SNIPPET_SQL} AS snip
+                    FROM decisions_fts f
+                    JOIN decisions d ON d.rowid = f.rowid
+                    WHERE {where_sql}
+                    ORDER BY rank
+                    LIMIT ? OFFSET ?""",
+                params + [int(limit), int(offset)],
+            ).fetchall()
 
-        total = conn.execute(
-            f"SELECT COUNT(*) FROM decisions_fts f JOIN decisions d ON d.rowid = f.rowid WHERE {where_sql}",
-            params,
-        ).fetchone()[0]
+            total = conn.execute(
+                f"SELECT COUNT(*) FROM decisions_fts f JOIN decisions d ON d.rowid = f.rowid WHERE {where_sql}",
+                params,
+            ).fetchone()[0]
+        except sqlite3.OperationalError as e:
+            return _fts_syntax_error_result(e)
 
         decisions = [
             {
@@ -230,7 +288,14 @@ def search_cc(
         raise ValueError("query must be non-empty")
     fts_query = _sanitize_fts5(query)
     if not fts_query:
-        return {"total": 0, "decisions": []}
+        return {
+            "total": 0,
+            "returned": 0,
+            "decisions": [],
+            "note": "Query vide après nettoyage FTS5 (caractères spéciaux "
+                    "retirés). Reformuler en mots-clés simples.",
+        }
+    limit = max(1, min(int(limit), 50))
     conn = _get_conn()
     try:
         SNIPPET = "snippet(decisions_fts, -1, '<em>', '</em>', '…', 28)"
@@ -249,11 +314,14 @@ def search_cc(
                f"d.numero, d.formation, d.ecli, d.nature, {SNIPPET} AS snip "
                f"FROM decisions_fts f JOIN decisions d ON d.rowid = f.rowid "
                f"WHERE {base_where} ORDER BY d.date DESC LIMIT ? OFFSET ?")
-        rows = conn.execute(sql, params + [int(limit), int(offset)]).fetchall()
-        total = conn.execute(
-            f"SELECT COUNT(*) FROM decisions_fts f JOIN decisions d ON d.rowid = f.rowid WHERE {base_where}",
-            params,
-        ).fetchone()[0]
+        try:
+            rows = conn.execute(sql, params + [int(limit), int(offset)]).fetchall()
+            total = conn.execute(
+                f"SELECT COUNT(*) FROM decisions_fts f JOIN decisions d ON d.rowid = f.rowid WHERE {base_where}",
+                params,
+            ).fetchone()[0]
+        except sqlite3.OperationalError as e:
+            return _fts_syntax_error_result(e)
         decisions = [{
             "id": r["id"], "titre": r["titre"], "date": r["date"],
             "juridiction": r["juridiction"], "solution": r["solution"],
@@ -279,7 +347,8 @@ def get_cc_decision(numero: str, nature: str | None = None) -> dict[str, Any] | 
     """
     if not numero.strip():
         return None
-    num_clean = numero.strip().replace(" ", " ")
+    # Un guillemet dans le numéro casserait la phrase FTS5 ci-dessous.
+    num_clean = numero.strip().replace('"', " ").replace(" ", " ")
     # FTS5 phrase match sur le numéro
     fts_q = f'"{num_clean}"'
     conn = _get_conn()

--- a/sources/european.py
+++ b/sources/european.py
@@ -10,6 +10,23 @@ from typing import Any
 
 DB_PATH = Path("/opt/justicelibre/dila/judiciaire.db")
 
+# Sanitizer + filet FTS5 partagés avec dila.py : FTS5 lève SyntaxError sur
+# certains caractères spéciaux (`:`, `\`, apostrophes…) — même moteur,
+# mêmes règles.
+from .dila import _fts_syntax_error_result, _sanitize_fts5
+
+def _empty_query_result() -> dict[str, Any]:
+    """Retour structuré quand la query est vide (avant ou après nettoyage FTS5) :
+    plus actionnable pour un agent qu'une exception opaque. Fonction (et non
+    constante) pour retourner une liste fraîche à chaque appel."""
+    return {
+        "total": 0,
+        "returned": 0,
+        "decisions": [],
+        "note": "Query vide après nettoyage FTS5 (caractères spéciaux retirés). "
+                "Reformuler en mots-clés simples.",
+    }
+
 
 def _conn():
     c = sqlite3.connect(str(DB_PATH), check_same_thread=False)
@@ -18,9 +35,17 @@ def _conn():
 
 
 def search_cedh(query: str, limit: int = 20, offset: int = 0) -> dict[str, Any]:
-    """Search CEDH (Cour EDH) via local HUDOC index."""
+    """Search CEDH (Cour EDH) via local HUDOC index. limit clampé à [1, 50]."""
     if not query.strip():
-        raise ValueError("query must be non-empty")
+        return _empty_query_result()
+    # Nettoie les caractères qui font planter FTS5 (préserve ", *, (), - et
+    # les opérateurs AND/OR/NOT — les queries construites par search_par_article
+    # passent intactes).
+    query = _sanitize_fts5(query)
+    if not query:
+        return _empty_query_result()
+    limit = max(1, min(int(limit), 50))
+    offset = max(0, int(offset))
     conn = _conn()
     try:
         # WHERE : exclut les docs sans texte exploitable (notes 002-* vides chez nous).
@@ -28,23 +53,26 @@ def search_cedh(query: str, limit: int = 20, offset: int = 0) -> dict[str, Any]:
         # 1) Préférer arrêts judiciaires complets (HFJUD, HEJUD) aux notes résumées (CLINF).
         # 2) Puis BM25 rank (pertinence query).
         # 3) Puis length(text) DESC (entre arrêts du même rank, le plus complet d'abord).
-        rows = conn.execute(
-            """SELECT d.itemid, d.docname, d.ecli, d.date, d.doctype,
-                      d.article, d.conclusion, d.importance, d.respondent,
-                      snippet(cedh_fts, -1, '<em>', '</em>', '…', 28) AS snip
-               FROM cedh_fts f JOIN cedh_decisions d ON d.rowid = f.rowid
-               WHERE cedh_fts MATCH ?
-                 AND length(COALESCE(d.text, '')) > 200
-               ORDER BY
-                 CASE WHEN d.doctype IN ('HFJUD', 'HEJUD') THEN 0 ELSE 1 END,
-                 rank,
-                 COALESCE(length(d.text), 0) DESC
-               LIMIT ? OFFSET ?""",
-            (query.strip(), int(limit), int(offset)),
-        ).fetchall()
-        total = conn.execute(
-            "SELECT COUNT(*) FROM cedh_fts WHERE cedh_fts MATCH ?", (query.strip(),)
-        ).fetchone()[0]
+        try:
+            rows = conn.execute(
+                """SELECT d.itemid, d.docname, d.ecli, d.date, d.doctype,
+                          d.article, d.conclusion, d.importance, d.respondent,
+                          snippet(cedh_fts, -1, '<em>', '</em>', '…', 28) AS snip
+                   FROM cedh_fts f JOIN cedh_decisions d ON d.rowid = f.rowid
+                   WHERE cedh_fts MATCH ?
+                     AND length(COALESCE(d.text, '')) > 200
+                   ORDER BY
+                     CASE WHEN d.doctype IN ('HFJUD', 'HEJUD') THEN 0 ELSE 1 END,
+                     rank,
+                     COALESCE(length(d.text), 0) DESC
+                   LIMIT ? OFFSET ?""",
+                (query.strip(), int(limit), int(offset)),
+            ).fetchall()
+            total = conn.execute(
+                "SELECT COUNT(*) FROM cedh_fts WHERE cedh_fts MATCH ?", (query.strip(),)
+            ).fetchone()[0]
+        except sqlite3.OperationalError as e:
+            return _fts_syntax_error_result(e)
         return {
             "total": total,
             "returned": len(rows),
@@ -95,15 +123,17 @@ def get_cedh(itemid: str) -> dict[str, Any] | None:
 
 
 def search_cjue(query: str, limit: int = 20, offset: int = 0) -> dict[str, Any]:
-    """Search CJUE via local EUR-Lex index.
+    """Search CJUE via local EUR-Lex index. limit clampé à [1, 50].
 
     Si la query matche un pattern n° d'affaire CJUE (`C-395/21`, `T-260/22`...),
     on boost l'arrêt dont c'est exactement le numéro pour qu'il remonte avant
     tous ceux qui le citent. Sinon BM25 standard."""
     if not query.strip():
-        raise ValueError("query must be non-empty")
+        return _empty_query_result()
     import re as _re
-    # Détecte un n° d'affaire dans la query (peut être seul ou inclus dans phrase)
+    # Détecte un n° d'affaire dans la query (peut être seul ou inclus dans phrase).
+    # IMPORTANT : détection sur la query BRUTE, car _sanitize_fts5 retire `/` et `.`
+    # dont ce pattern a besoin.
     m = _re.search(r"\b([CTF])[-\s.]*(\d{1,4})[/\-\s]+(\d{2,4})\b", query, _re.IGNORECASE)
     affaire_exact = None
     if m:
@@ -112,31 +142,40 @@ def search_cjue(query: str, limit: int = 20, offset: int = 0) -> dict[str, Any]:
         if len(year) == 4:
             year = year[2:]
         affaire_exact = f"{letter}-{num}/{year}"
+    # Nettoie les caractères qui font planter FTS5 (après la détection ci-dessus).
+    query = _sanitize_fts5(query)
+    if not query:
+        return _empty_query_result()
+    limit = max(1, min(int(limit), 50))
+    offset = max(0, int(offset))
     conn = _conn()
     try:
-        if affaire_exact:
-            # Boost massif : l'arrêt avec ce affaire_num exact passe en premier,
-            # puis BM25 sur les arrêts qui le citent.
-            rows = conn.execute(
-                """SELECT d.celex, d.ecli, d.date, d.type, d.title,
-                          snippet(cjue_fts, -1, '<em>', '</em>', '…', 28) AS snip
-                   FROM cjue_fts f JOIN cjue_decisions d ON d.rowid = f.rowid
-                   WHERE cjue_fts MATCH ?
-                   ORDER BY (CASE WHEN d.affaire_num = ? THEN 0 ELSE 1 END), rank
-                   LIMIT ? OFFSET ?""",
-                (query.strip(), affaire_exact, int(limit), int(offset)),
-            ).fetchall()
-        else:
-            rows = conn.execute(
-                """SELECT d.celex, d.ecli, d.date, d.type, d.title,
-                          snippet(cjue_fts, -1, '<em>', '</em>', '…', 28) AS snip
-                   FROM cjue_fts f JOIN cjue_decisions d ON d.rowid = f.rowid
-                   WHERE cjue_fts MATCH ? ORDER BY rank LIMIT ? OFFSET ?""",
-                (query.strip(), int(limit), int(offset)),
-            ).fetchall()
-        total = conn.execute(
-            "SELECT COUNT(*) FROM cjue_fts WHERE cjue_fts MATCH ?", (query.strip(),)
-        ).fetchone()[0]
+        try:
+            if affaire_exact:
+                # Boost massif : l'arrêt avec ce affaire_num exact passe en premier,
+                # puis BM25 sur les arrêts qui le citent.
+                rows = conn.execute(
+                    """SELECT d.celex, d.ecli, d.date, d.type, d.title,
+                              snippet(cjue_fts, -1, '<em>', '</em>', '…', 28) AS snip
+                       FROM cjue_fts f JOIN cjue_decisions d ON d.rowid = f.rowid
+                       WHERE cjue_fts MATCH ?
+                       ORDER BY (CASE WHEN d.affaire_num = ? THEN 0 ELSE 1 END), rank
+                       LIMIT ? OFFSET ?""",
+                    (query.strip(), affaire_exact, int(limit), int(offset)),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    """SELECT d.celex, d.ecli, d.date, d.type, d.title,
+                              snippet(cjue_fts, -1, '<em>', '</em>', '…', 28) AS snip
+                       FROM cjue_fts f JOIN cjue_decisions d ON d.rowid = f.rowid
+                       WHERE cjue_fts MATCH ? ORDER BY rank LIMIT ? OFFSET ?""",
+                    (query.strip(), int(limit), int(offset)),
+                ).fetchall()
+            total = conn.execute(
+                "SELECT COUNT(*) FROM cjue_fts WHERE cjue_fts MATCH ?", (query.strip(),)
+            ).fetchone()[0]
+        except sqlite3.OperationalError as e:
+            return _fts_syntax_error_result(e)
         return {
             "total": total,
             "returned": len(rows),

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -19,6 +19,7 @@ run tests/test_v2.py
 run tests/test_source_url.py
 run tests/test_citations.py
 run tests/test_annotations.py
+run tests/test_error_contract.py
 
 if [[ $INCLUDE_LIVE -eq 1 ]]; then
     echo "(les tests live sont déjà inclus dans test_search.py et test_v2.py)"

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -18,6 +18,7 @@ run tests/test_search.py
 run tests/test_v2.py
 run tests/test_source_url.py
 run tests/test_citations.py
+run tests/test_annotations.py
 
 if [[ $INCLUDE_LIVE -eq 1 ]]; then
     echo "(les tests live sont déjà inclus dans test_search.py et test_v2.py)"

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,0 +1,70 @@
+"""Test suite for MCP tool annotations.
+
+Locks down that every tool registered on the FastMCP server carries the
+safety annotations required by MCP clients (and by Anthropic's Connectors
+Directory review) : a human-readable `title` and `readOnlyHint: true`.
+The server is read-only by design — a new tool that writes data must set
+`destructiveHint` instead, and this test must be updated accordingly.
+
+Run :
+    python3 -m pytest tests/test_annotations.py -v
+ou :
+    python3 tests/test_annotations.py
+"""
+import asyncio
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(_HERE))
+
+import server  # noqa: E402
+
+
+def _list_tools():
+    return asyncio.run(server.mcp.list_tools())
+
+
+def test_every_tool_has_annotations():
+    missing = [t.name for t in _list_tools() if t.annotations is None]
+    assert not missing, "tools sans annotations :\n  " + "\n  ".join(missing)
+
+
+def test_every_tool_has_title():
+    missing = [
+        t.name for t in _list_tools()
+        if not (t.annotations and (t.annotations.title or "").strip())
+    ]
+    assert not missing, "tools sans title :\n  " + "\n  ".join(missing)
+
+
+def test_every_tool_is_read_only():
+    # Le serveur n'expose que de la consultation. Tout nouveau tool qui
+    # écrit doit porter destructiveHint et être exclu explicitement ici.
+    wrong = [
+        t.name for t in _list_tools()
+        if not (t.annotations and t.annotations.readOnlyHint is True)
+    ]
+    assert not wrong, "tools sans readOnlyHint=True :\n  " + "\n  ".join(wrong)
+
+
+# ─── Runner sans pytest ──────────────────────────────────────────
+
+if __name__ == "__main__":
+    tests = [
+        ("every tool has annotations", test_every_tool_has_annotations),
+        ("every tool has a title",     test_every_tool_has_title),
+        ("every tool is read-only",    test_every_tool_is_read_only),
+    ]
+    failed = 0
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"  ✓ {name}")
+        except AssertionError as e:
+            print(f"  ✗ {name}")
+            print(f"      {e}")
+            failed += 1
+    if failed:
+        sys.exit(1)
+    print(f"\nAll {len(tests)} tests passed.")

--- a/tests/test_error_contract.py
+++ b/tests/test_error_contract.py
@@ -1,0 +1,151 @@
+"""Test suite for the MCP error contract and tool schemas.
+
+Locks down the anti-pattern fixes required by Anthropic's "writing
+effective tools for agents" guidance and the Connectors Directory review :
+structured, actionable errors (`_tool_error`), offline validation errors
+(no DB touched), no credential parameters exposed in tool schemas,
+FTS5 query sanitization, and pagination (`offset`) on CEDH/CJUE search.
+
+All tests run OFFLINE — no local DB, no network.
+
+Run :
+    python3 -m pytest tests/test_error_contract.py -v
+ou :
+    python3 tests/test_error_contract.py
+"""
+import asyncio
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(_HERE))
+
+import server  # noqa: E402
+from sources import dila  # noqa: E402
+
+
+def _list_tools():
+    return asyncio.run(server.mcp.list_tools())
+
+
+def _tool_by_name(name):
+    for t in _list_tools():
+        if t.name == name:
+            return t
+    raise AssertionError(f"tool introuvable : {name}")
+
+
+def test_tool_error_shape():
+    err = server._tool_error("msg", category="validation", retryable=False, hint="x")
+    assert isinstance(err, dict), f"_tool_error doit retourner un dict, pas {type(err)}"
+    for key in ("error", "error_category", "retryable", "hint"):
+        assert key in err, f"clé manquante dans _tool_error : {key}"
+    assert isinstance(err["error"], str), "error doit être une str"
+    assert err["error_category"] == "validation"
+    assert err["retryable"] is False
+    assert err["hint"] == "x"
+
+
+def test_validation_errors_offline():
+    # Aucun paramètre → erreur de validation, sans toucher aucune DB.
+    res = asyncio.run(server.search_judiciaire_libre())
+    assert isinstance(res, dict), f"attendu un dict, reçu {type(res)}"
+    assert res.get("error_category") == "validation", \
+        f"search_judiciaire_libre() sans paramètre : error_category={res.get('error_category')!r}"
+
+    # Query composée uniquement d'espaces → erreur de validation.
+    res = asyncio.run(server.search_cedh(query="  "))
+    assert isinstance(res, dict), f"attendu un dict, reçu {type(res)}"
+    assert res.get("error_category") == "validation", \
+        f"search_cedh(query='  ') : error_category={res.get('error_category')!r}"
+
+
+def test_no_credentials_params():
+    # Aucun tool ne doit exposer un paramètre client_secret.
+    leaking = [
+        t.name for t in _list_tools()
+        if "client_secret" in (t.inputSchema or {}).get("properties", {})
+    ]
+    assert not leaking, "tools exposant client_secret :\n  " + "\n  ".join(leaking)
+
+    # search_judiciaire n'a plus de paramètre client_id.
+    props = (_tool_by_name("search_judiciaire").inputSchema or {}).get("properties", {})
+    assert "client_id" not in props, "search_judiciaire expose encore client_id"
+
+
+def test_fts5_sanitizer():
+    out = dila._sanitize_fts5("l'article 8 : (vie) *")
+    assert "'" not in out, f"apostrophe non nettoyée : {out!r}"
+    assert ":" not in out, f"deux-points non nettoyé : {out!r}"
+    # Les parenthèses hors groupe booléen (`mot (précision)`) sont une
+    # SyntaxError FTS5 → retirées. Elles ne survivent qu'avec AND/OR/NOT.
+    assert "(" not in out, f"parenthèses décoratives conservées : {out!r}"
+    boolean = dila._sanitize_fts5('("article 1240" OR "art 1240") AND "code civil"')
+    assert "(" in boolean and ")" in boolean, \
+        f"parenthèses de groupe booléen perdues : {boolean!r}"
+
+
+def test_fts5_sanitizer_real_engine():
+    # Verrou anti-régression : chaque query sanitizée doit passer MATCH sur
+    # un vrai index FTS5 (le cas "79-105" plantait avant le quoting des
+    # tokens à tiret).
+    import sqlite3
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE VIRTUAL TABLE t USING fts5(c)")
+    cases = [
+        "79-105 DC",
+        "garde-à-vue",
+        "l'article 8 : (vie familiale)",
+        'phrase "non fermée',
+        "mot - isolé",
+        "-negation",
+        "préfixe* et * seul",
+        '"phrase exacte" AND 79-105',
+        "C-72/24",
+        '("article 1240" OR "art 1240") AND ("code civil" OR "CC")',
+        "harcèlement AND",
+        'décision "79-105 DC"',
+    ]
+    failures = []
+    for case in cases:
+        sanitized = dila._sanitize_fts5(case)
+        if not sanitized:
+            continue  # query vide → gérée en amont par les sources
+        try:
+            conn.execute("SELECT count(*) FROM t WHERE t MATCH ?", (sanitized,))
+        except sqlite3.OperationalError as e:
+            failures.append(f"{case!r} -> {sanitized!r} : {e}")
+    conn.close()
+    assert not failures, "queries sanitizées rejetées par FTS5 :\n  " + \
+        "\n  ".join(failures)
+
+
+def test_pagination_params():
+    for name in ("search_cedh", "search_cjue"):
+        props = (_tool_by_name(name).inputSchema or {}).get("properties", {})
+        assert "offset" in props, f"{name} n'expose pas de paramètre offset"
+
+
+# ─── Runner sans pytest ──────────────────────────────────────────
+
+if __name__ == "__main__":
+    tests = [
+        ("_tool_error shape",           test_tool_error_shape),
+        ("validation errors offline",   test_validation_errors_offline),
+        ("no credentials params",       test_no_credentials_params),
+        ("fts5 sanitizer",              test_fts5_sanitizer),
+        ("fts5 sanitizer (moteur réel)", test_fts5_sanitizer_real_engine),
+        ("pagination params",           test_pagination_params),
+    ]
+    failed = 0
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"  ✓ {name}")
+        except AssertionError as e:
+            print(f"  ✗ {name}")
+            print(f"      {e}")
+            failed += 1
+    if failed:
+        sys.exit(1)
+    print(f"\nAll {len(tests)} tests passed.")


### PR DESCRIPTION
> ⚠️ **Basée sur #2** (annotations) — merger #2 d'abord, cette PR se rebasera proprement. Le diff affiché inclut #2 tant qu'elle n'est pas mergée.

## Motivation

Audit du serveur contre les [critères de review du Connectors Directory](https://claude.com/docs/connectors/building/review-criteria) et l'article [Writing effective tools for agents](https://www.anthropic.com/engineering/writing-tools-for-agents). Plusieurs anti-patterns identifiés, dont deux sérieux :

1. **Une source en panne = "0 résultat"** : dans `search_all`, une exception sur une source produisait un hit-fantôme sauté à la fusion — le modèle concluait « aucune jurisprudence n'existe » quand le warehouse avait un blip. Pour un outil juridique c'est le pire cas de figure.
2. **Secrets OAuth dans la conversation** : `search_judiciaire`/`get_decision_judiciaire` acceptaient `client_id`/`client_secret` en paramètres — le Client Secret PISTE transitait par le contexte LLM (historique, logs clients). Le mécanisme `session_token` existait précisément pour éviter ça.

## Changements

- **Contrat d'erreur uniforme** : helper `_tool_error` → `{error, error_category: validation|not_found|upstream|auth, retryable}` partout. Plus aucun tool ne retourne `None` (chaque introuvable suggère le tool alternatif), plus d'exception brute (les `raise_for_status()` PISTE sont catchés : 401 → régénérer le token, 429 → retryable).
- **Pannes visibles** : `search_all` et `search_decisions_citing` exposent `source_errors` + `warning` ; `per_source_counts` ne contient que les sources ayant répondu.
- **Suppression de `client_id`/`client_secret`** des tools PISTE. Restent : `session_token` (site) ou variables d'env `PISTE_CLIENT_ID`/`PISTE_CLIENT_SECRET` (auto-hébergement). ⚠️ breaking pour un client qui passait les credentials en clair — c'est voulu.
- **FTS5 durci** : sanitization partagée `dila`/`european` (les tokens à tiret — `79-105`, `garde-à-vue` — plantaient en `OperationalError` brut ; guillemets/parenthèses déséquilibrés ; opérateurs orphelins) + filet `OperationalError` → note actionnable. `limit` clampé [1,50] et `offset ≥ 0` côté sources.
- **Troncature annoncée** : `truncated` + `next_offset` sur les tools de recherche (pattern recommandé par l'article) ; `offset` ajouté à `search_cedh`, `search_cjue`, `search_judiciaire_libre` ; `search_admin_recent_all_ta` plafonné à 60 par défaut (0 = illimité reste possible).
- **Tokens ÷2 sur le tool le plus lourd** : `get_decision_text` renvoyait `text_segments` **et** `full_text` (le même arrêt deux fois) — `full_text` seul désormais.
- **Event loop** : les appels SQLite synchrones (dila/european) passent par `asyncio.to_thread` — le fan-out de `search_all` est réellement parallèle, et un client lent ne bloque plus les autres en Streamable HTTP.
- **Cohérence des chiffres** : instructions/`about_justicelibre`/docstrings disaient tour à tour 24 tools, ~4M JADE, ~620k judiciaire, 22/25/72 codes. Alignés sur les valeurs réelles (30 tools, ~550k, ~1,17M, 26 codes — compte exact de `SUPPORTED_CODES` —, ~8k CNIL).

## Vérification

- `tests/test_error_contract.py` (nouveau, offline) : contrat d'erreur, validation sans DB, absence de params credentials dans les schémas, sanitizer contre un **vrai index FTS5 en mémoire** (le cas `79-105` est verrouillé), pagination exposée.
- Suite complète au vert : `test_annotations` (3), `test_error_contract` (6), `test_source_url` (2), `test_citations` (2). `import server` + `list_tools()` → 30 tools.
- Rétrocompatibilité vérifiée : `search_api.py`/`token_server.py`/`ssr.py` inchangés dans leur comportement (le champ `error` reste une string, aucune clé renommée, `dila.search` lève toujours `ValueError` pour ses appelants internes).

## Hors périmètre (volontairement)

- La clé warehouse transite en clair (`http://` sur IP publique par défaut) et la protection DNS-rebinding est désactivée en prod : décisions d'infra qui vous appartiennent → issue séparée à venir.
- `token_server.py` (API REST publique) accepte `limit` jusqu'à 100 alors que les sources locales clampent désormais à 50 — sans gravité (résultats simplement plafonnés), à harmoniser si vous le souhaitez.
