### PR TITLE
Harnais d'évaluation MCP : 12 tâches juridiques vérifiables + boucle agentique

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,79 @@
+# Harnais d'évaluation MCP
+
+Mesure la capacité d'un agent LLM à répondre à des questions juridiques
+réalistes **avec les tools JusticeLibre** — la méthodologie recommandée par
+l'article Anthropic [Writing effective tools for
+agents](https://www.anthropic.com/engineering/writing-tools-for-agents) :
+prototyper, évaluer sur des tâches multi-appels vérifiables, analyser les
+transcripts, itérer.
+
+À quoi ça sert concrètement : objectiver l'impact d'un changement de
+design des tools (description, pagination, format d'erreur, consolidation)
+en comparant le taux de réussite et les métriques avant/après, au lieu
+d'en débattre à l'intuition.
+
+## Prérequis
+
+```bash
+pip install anthropic mcp   # mcp est déjà dans requirements.txt
+export ANTHROPIC_API_KEY=sk-ant-...   # ou profil `ant auth login`
+```
+
+Aucune base locale requise : par défaut le harnais interroge le endpoint
+public `https://justicelibre.org/mcp`.
+
+## Usage
+
+```bash
+# Valider connectivité MCP + schéma des tâches, sans consommer de tokens
+python3 evals/run_evals.py --dry-run
+
+# Tout lancer (12 tâches, ~2-5 min, de l'ordre de 100-300k tokens in / 10-30k out)
+python3 evals/run_evals.py
+
+# Un sous-ensemble, en voyant les appels de tools
+python3 evals/run_evals.py --tasks cedh-lookup,loi-timeline --verbose
+
+# Contre un serveur local (pour comparer avant/après un changement)
+python3 evals/run_evals.py --endpoint http://127.0.0.1:8765/mcp
+
+# Autre modèle
+python3 evals/run_evals.py --model claude-sonnet-5
+```
+
+Sortie : synthèse console (réussite, appels de tools, tokens, durées) +
+`evals/results.json` avec la réponse finale et le **transcript complet des
+appels de tools** de chaque tâche — c'est là que se lit *pourquoi* une
+tâche échoue (mauvais tool choisi, pagination ignorée, snippet pris pour
+le texte intégral…). Code retour : 0 si tout passe, 1 sinon.
+
+## Ce que mesurent les tâches
+
+| Dimension | Tâches |
+|---|---|
+| Articles de loi versionnés (killer feature) | `loi-version-historique`, `loi-version-courante`, `loi-timeline`, `loi-non-codifiee` |
+| Lookups par identifiant + routage inter-tools | `cc-qpc-lookup`, `cedh-lookup`, `ce-lookup` |
+| Workflows multi-appels | `citations-inverses`, `recherche-federee`, `chainage-snippet-texte` |
+| Robustesse (honnêteté sur vide, récupération d'erreur) | `honnetete-introuvable`, `robustesse-fts5` |
+
+Les faits attendus ont été vérifiés contre le endpoint live le
+2026-07-11. Les vérificateurs sont volontairement tolérants (insensibles
+casse/accents, jamais de comptage exact qui dériverait avec les mises à
+jour DILA).
+
+## Ajouter une tâche
+
+Dans `evals/tasks.py` : un prompt réaliste **multi-appels** (pas « appelle
+tel tool »), un vérificateur fondé sur un fait vérifié contre le serveur,
+et les tools attendus dans `expect_tool_any`. Lancer `--dry-run` : il
+valide le schéma et refuse un vérificateur qui accepterait une réponse
+vide.
+
+## Limites connues
+
+- Les tâches interrogent des données vivantes : un ré-import DILA peut
+  déplacer un attendu (préférer les identifiants stables aux comptages).
+- Le harnais tronque les résultats de tools à 30 000 caractères pour
+  protéger le contexte (borne indiquée au modèle).
+- Un run n'est pas déterministe : pour comparer deux versions du serveur,
+  lancer chaque version plusieurs fois et comparer les taux, pas un run sec.

--- a/evals/run_evals.py
+++ b/evals/run_evals.py
@@ -1,0 +1,298 @@
+"""Harnais d'évaluation du serveur MCP JusticeLibre.
+
+Méthodologie de l'article Anthropic « Writing effective tools for agents » :
+des tâches juridiques réalistes multi-appels (evals/tasks.py), une boucle
+agentique branchée sur le serveur MCP réel, des vérificateurs
+programmatiques, et des métriques au-delà de la précision (nombre
+d'appels de tools, tokens consommés, erreurs, durée) — les transcripts
+complets sont conservés dans le JSON de sortie pour analyse.
+
+Par défaut le harnais évalue le endpoint public (justicelibre.org/mcp) :
+aucune base locale requise. Nécessite `pip install anthropic mcp` et une
+clé API Anthropic (ANTHROPIC_API_KEY ou profil `ant auth login`).
+
+Usage :
+    python3 evals/run_evals.py                       # tout, endpoint public
+    python3 evals/run_evals.py --dry-run             # sans appel LLM
+    python3 evals/run_evals.py --tasks cedh-lookup,loi-timeline
+    python3 evals/run_evals.py --endpoint http://127.0.0.1:8765/mcp
+    python3 evals/run_evals.py --model claude-sonnet-5 --output out.json
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import re
+import sys
+import time
+import unicodedata
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from tasks import TASKS  # noqa: E402
+
+DEFAULT_ENDPOINT = "https://justicelibre.org/mcp"
+DEFAULT_MODEL = "claude-opus-4-8"
+DEFAULT_MAX_TURNS = 8
+MAX_TOKENS = 16000
+# Un texte intégral d'arrêt peut dépasser 100k caractères : on tronque les
+# résultats de tools pour protéger le contexte de l'agent (en le disant).
+TOOL_RESULT_MAX_CHARS = 30000
+
+SYSTEM_PROMPT = (
+    "Tu es un assistant de recherche juridique. Tu réponds en français en "
+    "t'appuyant EXCLUSIVEMENT sur les tools JusticeLibre fournis — jamais "
+    "sur ta mémoire pour les faits juridiques (textes, dates, numéros). "
+    "Cite les identifiants retournés par les tools quand ils existent."
+)
+
+
+# ─── Vérificateurs ───────────────────────────────────────────────────
+
+def _norm(s: str) -> str:
+    """minuscules + sans accents, pour des vérificateurs tolérants
+    (l'article Anthropic met en garde contre les verifiers trop stricts)."""
+    s = unicodedata.normalize("NFKD", s)
+    return "".join(c for c in s if not unicodedata.combining(c)).lower()
+
+
+def verify(task: dict, final_text: str, tools_called: list[str]) -> tuple[bool, list[str]]:
+    """Retourne (passed, détail des critères échoués)."""
+    failures: list[str] = []
+    text = _norm(final_text or "")
+    v = task.get("verify", {})
+    for sub in v.get("all_substrings", []):
+        if _norm(sub) not in text:
+            failures.append(f"substring attendue absente : {sub!r}")
+    any_subs = v.get("any_substrings", [])
+    if any_subs and not any(_norm(s) in text for s in any_subs):
+        failures.append(f"aucune des substrings attendues : {any_subs!r}")
+    if v.get("regex") and not re.search(v["regex"], final_text or "", re.IGNORECASE):
+        failures.append(f"regex sans match : {v['regex']!r}")
+    expected = task.get("expect_tool_any", [])
+    if expected and not any(t in tools_called for t in expected):
+        failures.append(f"aucun des tools attendus appelé : {expected!r} (appelés : {sorted(set(tools_called))!r})")
+    return (not failures, failures)
+
+
+# ─── Boucle agentique ────────────────────────────────────────────────
+
+def _mcp_result_to_text(result: Any) -> tuple[str, bool]:
+    """Aplatit un résultat MCP en texte pour le tool_result Anthropic."""
+    text = "".join(c.text for c in result.content if getattr(c, "text", None))
+    if not text.strip():
+        text = "(réponse vide)"
+    if len(text) > TOOL_RESULT_MAX_CHARS:
+        text = text[:TOOL_RESULT_MAX_CHARS] + (
+            "\n[... tronqué par le harnais d'évaluation : utiliser des "
+            "requêtes plus ciblées ou la pagination ...]"
+        )
+    return text, bool(getattr(result, "isError", False))
+
+
+async def run_task(client, session, anthropic_tools, task: dict, model: str, verbose: bool) -> dict:
+    """Exécute une tâche : boucle jusqu'à end_turn ou max_turns."""
+    max_turns = task.get("max_turns", DEFAULT_MAX_TURNS)
+    messages: list[dict] = [{"role": "user", "content": task["prompt"]}]
+    usage = {"input_tokens": 0, "output_tokens": 0,
+             "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0}
+    tools_called: list[str] = []
+    tool_errors = 0
+    transcript: list[dict] = []
+    final_text = ""
+    stop_reason = "max_turns_reached"
+    started = time.monotonic()
+
+    for _turn in range(max_turns):
+        response = await client.messages.create(
+            model=model,
+            max_tokens=MAX_TOKENS,
+            system=[{"type": "text", "text": SYSTEM_PROMPT,
+                     "cache_control": {"type": "ephemeral"}}],
+            thinking={"type": "adaptive"},
+            tools=anthropic_tools,
+            messages=messages,
+        )
+        for k in usage:
+            usage[k] += getattr(response.usage, k, 0) or 0
+
+        if response.stop_reason == "pause_turn":
+            messages.append({"role": "assistant", "content": response.content})
+            continue
+
+        tool_uses = [b for b in response.content if b.type == "tool_use"]
+        if response.stop_reason != "tool_use" or not tool_uses:
+            final_text = "\n".join(b.text for b in response.content if b.type == "text")
+            stop_reason = response.stop_reason
+            break
+
+        # Renvoyer le contenu assistant intact (thinking inclus), puis TOUS
+        # les tool_results dans UN SEUL message user (règle appels parallèles).
+        messages.append({"role": "assistant", "content": response.content})
+        results = await asyncio.gather(
+            *(session.call_tool(tu.name, arguments=tu.input) for tu in tool_uses)
+        )
+        tool_results = []
+        for tu, res in zip(tool_uses, results):
+            tools_called.append(tu.name)
+            text, is_error = _mcp_result_to_text(res)
+            tool_errors += int(is_error)
+            transcript.append({"tool": tu.name, "input": tu.input,
+                               "is_error": is_error, "result_excerpt": text[:600]})
+            if verbose:
+                print(f"      ⚙ {tu.name}({json.dumps(tu.input, ensure_ascii=False)[:120]})"
+                      f"{' [ERREUR]' if is_error else ''}")
+            tool_results.append({"type": "tool_result", "tool_use_id": tu.id,
+                                 "content": text, "is_error": is_error})
+        messages.append({"role": "user", "content": tool_results})
+
+    passed, failures = verify(task, final_text, tools_called)
+    return {
+        "id": task["id"],
+        "passed": passed,
+        "failures": failures,
+        "stop_reason": stop_reason,
+        "turns": len([m for m in messages if m["role"] == "assistant"]) + 1,
+        "tool_calls": len(tools_called),
+        "tools_called": tools_called,
+        "tool_errors": tool_errors,
+        "usage": usage,
+        "duration_s": round(time.monotonic() - started, 1),
+        "final_answer": final_text,
+        "transcript": transcript,
+    }
+
+
+# ─── Dry-run (sans LLM) ──────────────────────────────────────────────
+
+async def dry_run(session, anthropic_tools, tasks: list[dict]) -> int:
+    """Valide la connectivité MCP, le schéma des tâches et les tools
+    attendus, sans consommer de tokens."""
+    names = {t["name"] for t in anthropic_tools}
+    print(f"  ✓ endpoint MCP joignable — {len(names)} tools exposés")
+    errors = 0
+    seen_ids: set[str] = set()
+    for task in tasks:
+        problems = []
+        if task["id"] in seen_ids:
+            problems.append("id dupliqué")
+        seen_ids.add(task["id"])
+        if not task.get("prompt", "").strip():
+            problems.append("prompt vide")
+        if not task.get("verify"):
+            problems.append("aucun vérificateur")
+        missing = [t for t in task.get("expect_tool_any", []) if t not in names]
+        if missing:
+            problems.append(f"tools attendus absents du serveur : {missing}")
+        # Auto-test du vérificateur : il doit échouer sur une réponse vide
+        ok_empty, _ = verify(task, "", [])
+        if ok_empty:
+            problems.append("le vérificateur accepte une réponse vide")
+        if problems:
+            errors += 1
+            print(f"  ✗ {task['id']}: " + " ; ".join(problems))
+        else:
+            print(f"  ✓ {task['id']}")
+    print(f"\nDry-run : {len(tasks) - errors}/{len(tasks)} tâches valides.")
+    return 1 if errors else 0
+
+
+# ─── Main ────────────────────────────────────────────────────────────
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--endpoint", default=DEFAULT_ENDPOINT)
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--tasks", default="", help="ids séparés par des virgules")
+    parser.add_argument("--output", default="evals/results.json")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="valide MCP + tâches sans appel LLM")
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+
+    tasks = TASKS
+    if args.tasks:
+        wanted = {t.strip() for t in args.tasks.split(",") if t.strip()}
+        unknown = wanted - {t["id"] for t in TASKS}
+        if unknown:
+            print(f"Tâches inconnues : {sorted(unknown)}", file=sys.stderr)
+            return 2
+        tasks = [t for t in TASKS if t["id"] in wanted]
+
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamablehttp_client
+
+    async with streamablehttp_client(args.endpoint) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            listed = await session.list_tools()
+            # Ordre déterministe : la liste des tools est en tête du prompt,
+            # un ordre stable préserve le cache entre les tâches.
+            anthropic_tools = sorted(
+                ({"name": t.name, "description": t.description or "",
+                  "input_schema": t.inputSchema} for t in listed.tools),
+                key=lambda t: t["name"],
+            )
+
+            if args.dry_run:
+                return await dry_run(session, anthropic_tools, tasks)
+
+            import anthropic
+            client = anthropic.AsyncAnthropic()
+
+            results = []
+            print(f"Éval : {len(tasks)} tâches — modèle {args.model} — {args.endpoint}\n")
+            for i, task in enumerate(tasks, 1):
+                print(f"[{i}/{len(tasks)}] {task['id']} …")
+                try:
+                    r = await run_task(client, session, anthropic_tools,
+                                       task, args.model, args.verbose)
+                except anthropic.RateLimitError:
+                    print("      rate-limit — pause 60 s puis reprise")
+                    await asyncio.sleep(60)
+                    r = await run_task(client, session, anthropic_tools,
+                                       task, args.model, args.verbose)
+                except (anthropic.APIStatusError, anthropic.APIConnectionError) as e:
+                    r = {"id": task["id"], "passed": False,
+                         "failures": [f"erreur API : {e}"], "stop_reason": "api_error",
+                         "turns": 0, "tool_calls": 0, "tools_called": [],
+                         "tool_errors": 0, "usage": {}, "duration_s": 0.0,
+                         "final_answer": "", "transcript": []}
+                mark = "✓" if r["passed"] else "✗"
+                print(f"    {mark} {r['tool_calls']} appels, "
+                      f"{r['usage'].get('output_tokens', 0)} tokens out, "
+                      f"{r['duration_s']}s"
+                      + ("" if r["passed"] else f" — {'; '.join(r['failures'])}"))
+                results.append(r)
+
+    # ── Synthèse ──
+    passed = sum(1 for r in results if r["passed"])
+    tot_in = sum(r["usage"].get("input_tokens", 0) + r["usage"].get("cache_read_input_tokens", 0)
+                 + r["usage"].get("cache_creation_input_tokens", 0) for r in results)
+    tot_out = sum(r["usage"].get("output_tokens", 0) for r in results)
+    tot_calls = sum(r["tool_calls"] for r in results)
+    tot_errors = sum(r["tool_errors"] for r in results)
+    print(f"\n{'─' * 60}")
+    print(f"Réussite : {passed}/{len(results)} "
+          f"({100 * passed / max(len(results), 1):.0f} %)")
+    print(f"Appels de tools : {tot_calls} (dont {tot_errors} en erreur)")
+    print(f"Tokens : {tot_in} in (cache inclus) / {tot_out} out")
+
+    report = {
+        "endpoint": args.endpoint,
+        "model": args.model,
+        "passed": passed,
+        "total": len(results),
+        "results": results,
+    }
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, ensure_ascii=False, indent=2))
+    print(f"Rapport détaillé (transcripts inclus) : {out}")
+    return 0 if passed == len(results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/evals/tasks.py
+++ b/evals/tasks.py
@@ -1,0 +1,168 @@
+"""Tâches d'évaluation du serveur MCP JusticeLibre.
+
+Chaque tâche est une question juridique réaliste nécessitant un ou
+plusieurs appels de tools, avec un vérificateur programmatique. Les
+attendus ont été vérifiés contre le endpoint live (justicelibre.org/mcp)
+le 2026-07-11 — si la base évolue, préférer des vérifications
+structurelles (un identifiant, un mot du texte) aux comptages exacts,
+qui dérivent avec les mises à jour DILA.
+
+Format d'une tâche :
+    id                : slug unique (filtrable via --tasks)
+    prompt            : la question posée au modèle
+    verify            : dict de critères sur la RÉPONSE FINALE
+        all_substrings : toutes doivent apparaître (insensible casse/accents)
+        any_substrings : au moins une doit apparaître
+        regex          : re.search (insensible à la casse)
+    expect_tool_any   : au moins un de ces tools doit avoir été appelé
+    max_turns         : plafond de tours agentiques (défaut : 8)
+"""
+
+TASKS = [
+    # ── Killer feature : articles de loi versionnés ─────────────────
+    {
+        "id": "loi-version-historique",
+        "prompt": (
+            "Quel était le texte exact de l'article 1382 du Code civil "
+            "en vigueur en 1995 ? Cite le texte intégralement."
+        ),
+        "verify": {"all_substrings": ["tout fait quelconque de l'homme"]},
+        "expect_tool_any": ["get_law_article"],
+    },
+    {
+        "id": "loi-version-courante",
+        "prompt": (
+            "La règle « tout fait quelconque de l'homme qui cause à autrui "
+            "un dommage » est-elle encore à l'article 1382 du Code civil "
+            "aujourd'hui ? Si non, quel article la porte désormais ?"
+        ),
+        "verify": {"all_substrings": ["1240"]},
+        "expect_tool_any": ["get_law_article", "get_law_versions", "search_legi", "search_all"],
+    },
+    {
+        "id": "loi-timeline",
+        "prompt": (
+            "Combien de versions historiques l'article 1128 du Code civil "
+            "a-t-il connues, et quand la version actuelle est-elle entrée "
+            "en vigueur ?"
+        ),
+        "verify": {
+            "all_substrings": ["2016"],
+            "any_substrings": ["2 versions", "deux versions"],
+        },
+        "expect_tool_any": ["get_law_versions"],
+    },
+    {
+        "id": "loi-non-codifiee",
+        "prompt": (
+            "Trouve l'identifiant Légifrance de la loi n° 2000-321 et "
+            "donne sa date exacte."
+        ),
+        "verify": {
+            "all_substrings": ["JORFTEXT000000215117"],
+            "any_substrings": ["12 avril 2000", "2000-04-12", "2000-04-13"],
+        },
+        "expect_tool_any": ["resolve_law_number"],
+    },
+    # ── Lookups par identifiant (routage inter-tools) ───────────────
+    {
+        "id": "cc-qpc-lookup",
+        "prompt": (
+            "De quoi traite la décision n° 2023-1048 QPC du Conseil "
+            "constitutionnel, et à quelle date a-t-elle été rendue ?"
+        ),
+        "verify": {"all_substrings": ["résident", "2023"]},
+        "expect_tool_any": ["get_cc_decision", "search_cc"],
+    },
+    {
+        "id": "cedh-lookup",
+        "prompt": (
+            "Récupère la décision CEDH portant l'itemid 001-249914 : "
+            "quel est le nom de l'affaire, l'État défendeur et la "
+            "conclusion ?"
+        ),
+        "verify": {
+            "all_substrings": ["monaco"],
+            "any_substrings": ["radiation"],
+        },
+        "expect_tool_any": ["get_decision_cedh"],
+    },
+    {
+        "id": "ce-lookup",
+        "prompt": (
+            "Quelle est la date de lecture de la décision du Conseil "
+            "d'État n° 473286, et quel est son identifiant interne "
+            "JusticeLibre ?"
+        ),
+        "verify": {
+            "all_substrings": ["473286"],
+            "any_substrings": ["2023-11-23", "23 novembre 2023", "DCE_473286"],
+        },
+        "expect_tool_any": ["get_admin_decision", "get_ce_decision"],
+    },
+    # ── Workflows multi-appels ──────────────────────────────────────
+    {
+        "id": "citations-inverses",
+        "prompt": (
+            "Quelles décisions de justice citent explicitement l'article "
+            "L1152-1 du Code du travail (harcèlement moral) ? Donne "
+            "l'identifiant d'une décision judiciaire qui le cite."
+        ),
+        "verify": {"any_substrings": ["JURITEXT"]},
+        "expect_tool_any": ["search_decisions_citing"],
+    },
+    {
+        "id": "recherche-federee",
+        "prompt": (
+            "Fais un panorama des sources de jurisprudence disponibles "
+            "sur le harcèlement moral : combien de résultats par source ?"
+        ),
+        "verify": {"any_substrings": ["dila", "jade", "cedh", "cjue", "judiciaire", "administrat"]},
+        "expect_tool_any": ["search_all"],
+    },
+    {
+        "id": "chainage-snippet-texte",
+        "prompt": (
+            "Trouve un arrêt de la Cour de cassation portant sur la garde "
+            "à vue et cite un passage de son TEXTE INTÉGRAL (pas "
+            "seulement l'extrait de recherche)."
+        ),
+        # Le point testé : enchaîner search → get (la règle impérative des
+        # instructions du serveur) au lieu de conclure depuis le snippet.
+        "verify": {"all_substrings": ["garde à vue"]},
+        "expect_tool_any": ["get_decision_judiciaire_libre"],
+    },
+    # ── Robustesse ──────────────────────────────────────────────────
+    {
+        "id": "honnetete-introuvable",
+        "prompt": (
+            "Récupère la décision CEDH portant l'itemid 001-9999999 et "
+            "résume son contenu."
+        ),
+        # L'itemid n'existe pas : le modèle doit le dire, pas inventer un
+        # résumé. (Verrouille l'anti-hallucination sur résultat vide.)
+        "verify": {
+            "any_substrings": [
+                "introuvable", "pas trouvé", "n'existe pas", "aucune décision",
+                "pas de décision", "ne correspond", "invalide", "n'a pas été trouvée",
+                "ne semble pas exister", "impossible de récupérer", "n'ai pas pu",
+            ],
+        },
+        "expect_tool_any": ["get_decision_cedh"],
+    },
+    {
+        "id": "robustesse-fts5",
+        "prompt": (
+            "Trouve l'arrêt de la CJUE dans l'affaire C-131/12 (Google "
+            "Spain, droit au déréférencement) et donne son identifiant "
+            "CELEX ou ECLI."
+        ),
+        # La query brute « C-131/12 » fait planter FTS5 sur le serveur
+        # pré-correctif (syntax error near "/") : la tâche mesure si
+        # l'agent se rétablit (reformulation) ou si le serveur nettoie
+        # la query. Attendu en hausse après le fix sanitization FTS5.
+        "verify": {"any_substrings": ["62012", "celex", "ecli", "google"]},
+        "expect_tool_any": ["search_cjue", "get_decision_cjue"],
+        "max_turns": 10,
+    },
+]


### PR DESCRIPTION
## Motivation

JusticeLibre n'a aujourd'hui aucun moyen d'objectiver l'impact d'un changement de design des tools (description, pagination, format d'erreur, consolidation…) sur la capacité réelle d'un agent à s'en servir. Cette PR ajoute le harnais d'évaluation recommandé par l'article Anthropic [Writing effective tools for agents](https://www.anthropic.com/engineering/writing-tools-for-agents) : des tâches réalistes multi-appels avec vérificateurs, une boucle agentique sur le serveur MCP réel, et des métriques au-delà de la précision.

Concrètement : avant de merger un changement de design, on lance l'éval sur les deux versions et on compare taux de réussite / appels de tools / tokens — au lieu d'en débattre à l'intuition.

## Contenu

- **`evals/tasks.py`** — 12 tâches juridiques réalistes couvrant 4 dimensions : articles de loi versionnés (la killer feature), lookups par identifiant + routage inter-tools, workflows multi-appels (dont la règle impérative snippet → texte intégral), et robustesse (honnêteté sur résultat vide, récupération d'erreur). Tous les attendus sont **ground-truthés contre le endpoint live** (2026-07-11) — aucun fait de mémoire. Les vérificateurs sont volontairement tolérants (insensibles casse/accents, jamais de comptage exact qui dériverait avec les mises à jour DILA).
- **`evals/run_evals.py`** — boucle agentique (SDK Anthropic + client MCP streamable HTTP), endpoint public par défaut donc **aucune DB locale requise** ; appels de tools parallèles gérés, résultats tronqués à 30k chars (borne annoncée au modèle), usage tokens accumulé cache inclus, transcripts complets dans `results.json`. Modèle par défaut `claude-opus-4-8` (`--model` pour changer).
- **`evals/README.md`** — usage, coût indicatif, comment ajouter une tâche, limites.

## Mode `--dry-run` (zéro token)

Valide la connectivité MCP, le schéma des tâches, l'existence des tools attendus sur le serveur, et refuse tout vérificateur qui accepterait une réponse vide. **Vérifié contre justicelibre.org/mcp : 12/12.** Le run complet nécessite une clé `ANTHROPIC_API_KEY` (je n'en avais pas sous la main — le dry-run et les vérificateurs sont testés, la boucle LLM suit strictement les patterns documentés du SDK).

## Bonus trouvé en ground-truthant

La tâche `robustesse-fts5` reproduit un crash réel du serveur actuel : `search_cjue("C-131/12 Google Spain")` → `fts5: syntax error near "/"` (le `/` du numéro d'affaire). C'est précisément la famille de bugs corrigée par #4 — une fois #4 mergée, cette tâche devrait passer sans que l'agent ait à se rattraper.

Volontairement **hors** de `tests/run_all.sh` : l'éval a besoin du réseau et d'une clé API, ce n'est pas un test de régression offline.
