### PR TITLE
Fix corruption de l'index FTS5 à la ré-importation (triggers _ad/_au + recursive_triggers)

### DIFF
--- a/download_opendata.py
+++ b/download_opendata.py
@@ -171,6 +171,20 @@ def insert_decision(c: sqlite3.Connection, hit: dict, full_text: str | None):
         return False
     # last_modified est plus fiable que Date_Lecture pour le tri/lastmod sitemap
     date_for_sitemap = src.get("Date_Lecture") or src.get("lastModified", "")[:10]
+    # opendata_fts est contentless (content='') et maintenu à la main : le
+    # INSERT OR REPLACE ci-dessous réassigne un nouveau rowid à la décision,
+    # laissant l'ancienne entrée FTS orpheline (recherche corrompue à la
+    # ré-importation). On purge donc l'ancienne entrée AVANT le REPLACE, avec
+    # ses valeurs exactes (contentless exige la commande 'delete' + valeurs).
+    old = c.execute(
+        "SELECT rowid, id, juridiction_name, numero_dossier, texte "
+        "FROM opendata_decisions WHERE id = ?", (decision_id,)
+    ).fetchone()
+    if old and old[4]:  # ancienne entrée FTS présente seulement si texte non vide
+        c.execute(
+            "INSERT INTO opendata_fts(opendata_fts, rowid, id, juridiction, "
+            "numero_dossier, texte) VALUES ('delete', ?, ?, ?, ?, ?)", old
+        )
     c.execute("""
         INSERT OR REPLACE INTO opendata_decisions
         (id, juridiction_code, juridiction_name, date, numero_dossier, ecli,

--- a/index_dila.py
+++ b/index_dila.py
@@ -177,6 +177,7 @@ ALL_COLS = BASE_COLS + EXTRA_COLS
 def create_db(db_path: str) -> sqlite3.Connection:
     conn = sqlite3.connect(db_path)
     conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA recursive_triggers=ON")  # INSERT OR REPLACE doit déclencher le trigger _ad du FTS5
     conn.execute("PRAGMA synchronous=NORMAL")
 
     # Table de base avec les 12 colonnes historiques
@@ -219,6 +220,22 @@ def create_db(db_path: str) -> sqlite3.Connection:
 
     conn.execute("""
         CREATE TRIGGER IF NOT EXISTS decisions_ai AFTER INSERT ON decisions BEGIN
+            INSERT INTO decisions_fts(rowid, id, titre, juridiction, solution, numero, formation, text)
+            VALUES (new.rowid, new.id, new.titre, new.juridiction, new.solution, new.numero, new.formation, new.text);
+        END
+    """)
+
+    conn.execute("""
+        CREATE TRIGGER IF NOT EXISTS decisions_ad AFTER DELETE ON decisions BEGIN
+            INSERT INTO decisions_fts(decisions_fts, rowid, id, titre, juridiction, solution, numero, formation, text)
+            VALUES ('delete', old.rowid, old.id, old.titre, old.juridiction, old.solution, old.numero, old.formation, old.text);
+        END
+    """)
+
+    conn.execute("""
+        CREATE TRIGGER IF NOT EXISTS decisions_au AFTER UPDATE ON decisions BEGIN
+            INSERT INTO decisions_fts(decisions_fts, rowid, id, titre, juridiction, solution, numero, formation, text)
+            VALUES ('delete', old.rowid, old.id, old.titre, old.juridiction, old.solution, old.numero, old.formation, old.text);
             INSERT INTO decisions_fts(rowid, id, titre, juridiction, solution, numero, formation, text)
             VALUES (new.rowid, new.id, new.titre, new.juridiction, new.solution, new.numero, new.formation, new.text);
         END

--- a/judilibre_sync.py
+++ b/judilibre_sync.py
@@ -287,6 +287,7 @@ def main() -> int:
         p.error("--rgs ou --history requis")
     conn = sqlite3.connect(DB, timeout=300)
     conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA recursive_triggers=ON")  # INSERT OR REPLACE doit déclencher le trigger _ad du FTS5
     token = get_token()
     headers = {"Authorization": f"Bearer {token}"}
     rc = 0

--- a/parse_dila_bulk.py
+++ b/parse_dila_bulk.py
@@ -48,6 +48,7 @@ def parse_legi():
     db = DB_DIR / "legi.db"
     conn = sqlite3.connect(db, timeout=120.0)
     conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA recursive_triggers=ON")  # INSERT OR REPLACE doit déclencher le trigger _ad du FTS5
     conn.execute("PRAGMA synchronous=NORMAL")
     conn.execute("PRAGMA cache_size=-131072")  # 128 MB
     conn.execute("PRAGMA temp_store=MEMORY")
@@ -85,6 +86,16 @@ def parse_legi():
         content='legi_articles', content_rowid='rowid'
     );
     CREATE TRIGGER IF NOT EXISTS legi_art_ai AFTER INSERT ON legi_articles BEGIN
+        INSERT INTO legi_articles_fts(rowid, legiarti, titre_text, num, texte)
+        VALUES (new.rowid, new.legiarti, new.titre_text, new.num, new.texte);
+    END;
+    CREATE TRIGGER IF NOT EXISTS legi_art_ad AFTER DELETE ON legi_articles BEGIN
+        INSERT INTO legi_articles_fts(legi_articles_fts, rowid, legiarti, titre_text, num, texte)
+        VALUES ('delete', old.rowid, old.legiarti, old.titre_text, old.num, old.texte);
+    END;
+    CREATE TRIGGER IF NOT EXISTS legi_art_au AFTER UPDATE ON legi_articles BEGIN
+        INSERT INTO legi_articles_fts(legi_articles_fts, rowid, legiarti, titre_text, num, texte)
+        VALUES ('delete', old.rowid, old.legiarti, old.titre_text, old.num, old.texte);
         INSERT INTO legi_articles_fts(rowid, legiarti, titre_text, num, texte)
         VALUES (new.rowid, new.legiarti, new.titre_text, new.num, new.texte);
     END;
@@ -226,6 +237,7 @@ def parse_jorf_like(fund: str):
     db = DB_DIR / f"{fund}.db"
     conn = sqlite3.connect(db, timeout=120.0)
     conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA recursive_triggers=ON")  # INSERT OR REPLACE doit déclencher le trigger _ad du FTS5
     conn.execute("PRAGMA synchronous=NORMAL")
     conn.execute("PRAGMA cache_size=-131072")
     conn.executescript(f"""
@@ -249,6 +261,16 @@ def parse_jorf_like(fund: str):
         content='{fund}_textes', content_rowid='rowid'
     );
     CREATE TRIGGER IF NOT EXISTS {fund}_ai AFTER INSERT ON {fund}_textes BEGIN
+        INSERT INTO {fund}_fts(rowid, jorftext, titre, nature, ministere, texte, nota)
+        VALUES (new.rowid, new.jorftext, new.titre, new.nature, new.ministere, new.texte, new.nota);
+    END;
+    CREATE TRIGGER IF NOT EXISTS {fund}_ad AFTER DELETE ON {fund}_textes BEGIN
+        INSERT INTO {fund}_fts({fund}_fts, rowid, jorftext, titre, nature, ministere, texte, nota)
+        VALUES ('delete', old.rowid, old.jorftext, old.titre, old.nature, old.ministere, old.texte, old.nota);
+    END;
+    CREATE TRIGGER IF NOT EXISTS {fund}_au AFTER UPDATE ON {fund}_textes BEGIN
+        INSERT INTO {fund}_fts({fund}_fts, rowid, jorftext, titre, nature, ministere, texte, nota)
+        VALUES ('delete', old.rowid, old.jorftext, old.titre, old.nature, old.ministere, old.texte, old.nota);
         INSERT INTO {fund}_fts(rowid, jorftext, titre, nature, ministere, texte, nota)
         VALUES (new.rowid, new.jorftext, new.titre, new.nature, new.ministere, new.texte, new.nota);
     END;
@@ -346,6 +368,7 @@ def parse_juris(fund: str):
     db = DB_DIR / f"{fund}.db"
     conn = sqlite3.connect(db, timeout=120.0)
     conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA recursive_triggers=ON")  # INSERT OR REPLACE doit déclencher le trigger _ad du FTS5
     conn.execute("PRAGMA synchronous=NORMAL")
     conn.execute("PRAGMA cache_size=-131072")
     conn.executescript(f"""
@@ -374,6 +397,16 @@ def parse_juris(fund: str):
         content='{fund}_decisions', content_rowid='rowid'
     );
     CREATE TRIGGER IF NOT EXISTS {fund}_ai AFTER INSERT ON {fund}_decisions BEGIN
+        INSERT INTO {fund}_fts(rowid, id, juridiction, numero, titre, sommaire, texte)
+        VALUES (new.rowid, new.id, new.juridiction, new.numero, new.titre, new.sommaire, new.texte);
+    END;
+    CREATE TRIGGER IF NOT EXISTS {fund}_ad AFTER DELETE ON {fund}_decisions BEGIN
+        INSERT INTO {fund}_fts({fund}_fts, rowid, id, juridiction, numero, titre, sommaire, texte)
+        VALUES ('delete', old.rowid, old.id, old.juridiction, old.numero, old.titre, old.sommaire, old.texte);
+    END;
+    CREATE TRIGGER IF NOT EXISTS {fund}_au AFTER UPDATE ON {fund}_decisions BEGIN
+        INSERT INTO {fund}_fts({fund}_fts, rowid, id, juridiction, numero, titre, sommaire, texte)
+        VALUES ('delete', old.rowid, old.id, old.juridiction, old.numero, old.titre, old.sommaire, old.texte);
         INSERT INTO {fund}_fts(rowid, id, juridiction, numero, titre, sommaire, texte)
         VALUES (new.rowid, new.id, new.juridiction, new.numero, new.titre, new.sommaire, new.texte);
     END;
@@ -482,6 +515,7 @@ def parse_kali():
     db = DB_DIR / "kali.db"
     conn = sqlite3.connect(db, timeout=120.0)
     conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA recursive_triggers=ON")  # INSERT OR REPLACE doit déclencher le trigger _ad du FTS5
     conn.execute("PRAGMA synchronous=NORMAL")
     conn.executescript("""
     CREATE TABLE IF NOT EXISTS kali_textes (
@@ -501,6 +535,16 @@ def parse_kali():
         content='kali_textes', content_rowid='rowid'
     );
     CREATE TRIGGER IF NOT EXISTS kali_ai AFTER INSERT ON kali_textes BEGIN
+        INSERT INTO kali_fts(rowid, id, idcc, titre, texte)
+        VALUES (new.rowid, new.id, new.idcc, new.titre, new.texte);
+    END;
+    CREATE TRIGGER IF NOT EXISTS kali_ad AFTER DELETE ON kali_textes BEGIN
+        INSERT INTO kali_fts(kali_fts, rowid, id, idcc, titre, texte)
+        VALUES ('delete', old.rowid, old.id, old.idcc, old.titre, old.texte);
+    END;
+    CREATE TRIGGER IF NOT EXISTS kali_au AFTER UPDATE ON kali_textes BEGIN
+        INSERT INTO kali_fts(kali_fts, rowid, id, idcc, titre, texte)
+        VALUES ('delete', old.rowid, old.id, old.idcc, old.titre, old.texte);
         INSERT INTO kali_fts(rowid, id, idcc, titre, texte)
         VALUES (new.rowid, new.id, new.idcc, new.titre, new.texte);
     END;
@@ -583,6 +627,7 @@ def parse_cnil():
     db = DB_DIR / "cnil.db"
     conn = sqlite3.connect(db, timeout=120.0)
     conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA recursive_triggers=ON")  # INSERT OR REPLACE doit déclencher le trigger _ad du FTS5
     conn.executescript("""
     CREATE TABLE IF NOT EXISTS cnil_deliberations (
         id TEXT PRIMARY KEY,
@@ -597,6 +642,16 @@ def parse_cnil():
         content='cnil_deliberations', content_rowid='rowid'
     );
     CREATE TRIGGER IF NOT EXISTS cnil_ai AFTER INSERT ON cnil_deliberations BEGIN
+        INSERT INTO cnil_fts(rowid, id, numero, titre, formation, texte)
+        VALUES (new.rowid, new.id, new.numero, new.titre, new.formation, new.texte);
+    END;
+    CREATE TRIGGER IF NOT EXISTS cnil_ad AFTER DELETE ON cnil_deliberations BEGIN
+        INSERT INTO cnil_fts(cnil_fts, rowid, id, numero, titre, formation, texte)
+        VALUES ('delete', old.rowid, old.id, old.numero, old.titre, old.formation, old.texte);
+    END;
+    CREATE TRIGGER IF NOT EXISTS cnil_au AFTER UPDATE ON cnil_deliberations BEGIN
+        INSERT INTO cnil_fts(cnil_fts, rowid, id, numero, titre, formation, texte)
+        VALUES ('delete', old.rowid, old.id, old.numero, old.titre, old.formation, old.texte);
         INSERT INTO cnil_fts(rowid, id, numero, titre, formation, texte)
         VALUES (new.rowid, new.id, new.numero, new.titre, new.formation, new.texte);
     END;

--- a/rescrape_cedh.py
+++ b/rescrape_cedh.py
@@ -153,6 +153,7 @@ def find_text_with_fallback(client, itemid, ecli):
 def main():
     conn = sqlite3.connect(DB_PATH, timeout=120.0)
     conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA recursive_triggers=ON")  # INSERT OR REPLACE doit déclencher le trigger _ad du FTS5
     conn.execute("PRAGMA busy_timeout=120000")
 
     rows = conn.execute(

--- a/scrape_ariane.py
+++ b/scrape_ariane.py
@@ -59,6 +59,16 @@ def ensure_schema(conn):
         INSERT INTO ariane_fts(rowid, ariane_id, text)
         VALUES (new.rowid, new.ariane_id, new.text);
     END;
+    CREATE TRIGGER IF NOT EXISTS ariane_ad AFTER DELETE ON ariane_decisions BEGIN
+        INSERT INTO ariane_fts(ariane_fts, rowid, ariane_id, text)
+        VALUES ('delete', old.rowid, old.ariane_id, old.text);
+    END;
+    CREATE TRIGGER IF NOT EXISTS ariane_au AFTER UPDATE ON ariane_decisions BEGIN
+        INSERT INTO ariane_fts(ariane_fts, rowid, ariane_id, text)
+        VALUES ('delete', old.rowid, old.ariane_id, old.text);
+        INSERT INTO ariane_fts(rowid, ariane_id, text)
+        VALUES (new.rowid, new.ariane_id, new.text);
+    END;
     """)
     conn.commit()
 
@@ -114,6 +124,7 @@ def main():
     print(f"[ariane] start ; UA = {USER_AGENT}")
     conn = sqlite3.connect(DB_PATH, timeout=120.0)
     conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA recursive_triggers=ON")  # INSERT OR REPLACE doit déclencher le trigger _ad du FTS5
     conn.execute("PRAGMA busy_timeout=120000")
     conn.execute("PRAGMA cache_size=-32000")
     ensure_schema(conn)

--- a/scrape_cedh.py
+++ b/scrape_cedh.py
@@ -49,6 +49,16 @@ def ensure_schema(conn):
         INSERT INTO cedh_fts(rowid, itemid, docname, article, conclusion, text)
         VALUES (new.rowid, new.itemid, new.docname, new.article, new.conclusion, new.text);
     END;
+    CREATE TRIGGER IF NOT EXISTS cedh_ad AFTER DELETE ON cedh_decisions BEGIN
+        INSERT INTO cedh_fts(cedh_fts, rowid, itemid, docname, article, conclusion, text)
+        VALUES ('delete', old.rowid, old.itemid, old.docname, old.article, old.conclusion, old.text);
+    END;
+    CREATE TRIGGER IF NOT EXISTS cedh_au AFTER UPDATE ON cedh_decisions BEGIN
+        INSERT INTO cedh_fts(cedh_fts, rowid, itemid, docname, article, conclusion, text)
+        VALUES ('delete', old.rowid, old.itemid, old.docname, old.article, old.conclusion, old.text);
+        INSERT INTO cedh_fts(rowid, itemid, docname, article, conclusion, text)
+        VALUES (new.rowid, new.itemid, new.docname, new.article, new.conclusion, new.text);
+    END;
     """)
     conn.commit()
 
@@ -89,6 +99,7 @@ def fetch_text(client, itemid):
 def main():
     conn = sqlite3.connect(DB_PATH, timeout=120.0)
     conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA recursive_triggers=ON")  # INSERT OR REPLACE doit déclencher le trigger _ad du FTS5
     conn.execute("PRAGMA busy_timeout=120000")
     conn.execute("PRAGMA cache_size=-8000")
     ensure_schema(conn)

--- a/scrape_cedh_gaps.py
+++ b/scrape_cedh_gaps.py
@@ -89,6 +89,7 @@ def list_all_itemids_for_year(client, year):
 def main():
     conn = sqlite3.connect(DB_PATH, timeout=120.0)
     conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA recursive_triggers=ON")  # INSERT OR REPLACE doit déclencher le trigger _ad du FTS5
     conn.execute("PRAGMA busy_timeout=120000")
 
     existing = conn.execute("SELECT COUNT(*) FROM cedh_decisions").fetchone()[0]

--- a/scrape_cjue.py
+++ b/scrape_cjue.py
@@ -56,6 +56,16 @@ def ensure_schema(conn):
         INSERT INTO cjue_fts(rowid, celex, ecli, title, text)
         VALUES (new.rowid, new.celex, new.ecli, new.title, new.text);
     END;
+    CREATE TRIGGER IF NOT EXISTS cjue_ad AFTER DELETE ON cjue_decisions BEGIN
+        INSERT INTO cjue_fts(cjue_fts, rowid, celex, ecli, title, text)
+        VALUES ('delete', old.rowid, old.celex, old.ecli, old.title, old.text);
+    END;
+    CREATE TRIGGER IF NOT EXISTS cjue_au AFTER UPDATE ON cjue_decisions BEGIN
+        INSERT INTO cjue_fts(cjue_fts, rowid, celex, ecli, title, text)
+        VALUES ('delete', old.rowid, old.celex, old.ecli, old.title, old.text);
+        INSERT INTO cjue_fts(rowid, celex, ecli, title, text)
+        VALUES (new.rowid, new.celex, new.ecli, new.title, new.text);
+    END;
     """)
     conn.commit()
 
@@ -117,6 +127,7 @@ def celex_to_ecli(celex):
 def main():
     conn = sqlite3.connect(DB_PATH, timeout=120.0)
     conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA recursive_triggers=ON")  # INSERT OR REPLACE doit déclencher le trigger _ad du FTS5
     conn.execute("PRAGMA busy_timeout=120000")
     conn.execute("PRAGMA cache_size=-8000")
     ensure_schema(conn)

--- a/scrape_legifrance.py
+++ b/scrape_legifrance.py
@@ -85,6 +85,16 @@ def ensure_schema(conn):
         INSERT INTO articles_fts(rowid, article_id, code_titre_court, num, titre, texte)
         VALUES (new.rowid, new.article_id, new.code_titre_court, new.num, new.titre, new.texte);
     END;
+    CREATE TRIGGER IF NOT EXISTS art_ad AFTER DELETE ON articles_loi BEGIN
+        INSERT INTO articles_fts(articles_fts, rowid, article_id, code_titre_court, num, titre, texte)
+        VALUES ('delete', old.rowid, old.article_id, old.code_titre_court, old.num, old.titre, old.texte);
+    END;
+    CREATE TRIGGER IF NOT EXISTS art_au AFTER UPDATE ON articles_loi BEGIN
+        INSERT INTO articles_fts(articles_fts, rowid, article_id, code_titre_court, num, titre, texte)
+        VALUES ('delete', old.rowid, old.article_id, old.code_titre_court, old.num, old.titre, old.texte);
+        INSERT INTO articles_fts(rowid, article_id, code_titre_court, num, titre, texte)
+        VALUES (new.rowid, new.article_id, new.code_titre_court, new.num, new.titre, new.texte);
+    END;
     """)
     conn.commit()
 
@@ -142,6 +152,7 @@ def fetch_article(client, headers, article_id):
 def main():
     conn = sqlite3.connect(DB_PATH, timeout=120.0)
     conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA recursive_triggers=ON")  # INSERT OR REPLACE doit déclencher le trigger _ad du FTS5
     conn.execute("PRAGMA busy_timeout=120000")
     ensure_schema(conn)
 

--- a/scripts/rebuild_fts.py
+++ b/scripts/rebuild_fts.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Reconstruit les index FTS5 pour purger les orphelins historiques.
+
+À lancer UNE FOIS après déploiement du correctif « triggers FTS5 + PRAGMA
+recursive_triggers ». Avant le correctif, chaque ré-importation (INSERT OR
+REPLACE) laissait des entrées FTS orphelines pointant des rowids disparus —
+recherche corrompue, voire crash `fts5: missing row from content table`. Le
+correctif empêche l'accumulation future ; ce script nettoie l'existant.
+
+Idempotent et sûr : `INSERT INTO <fts>(<fts>) VALUES('rebuild')` reconstruit
+l'index depuis la table de contenu. Coûteux sur les gros fonds (legi, jade) —
+prévoir plusieurs minutes, à lancer hors des heures de parse.
+
+Usage :
+    python3 scripts/rebuild_fts.py                 # tous les fonds
+    python3 scripts/rebuild_fts.py --db /opt/justicelibre/dila/legi.db
+    python3 scripts/rebuild_fts.py --dry-run       # liste sans reconstruire
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sqlite3
+import sys
+import time
+
+# (chemin de la base, tables FTS à reconstruire). Chemins par défaut de la
+# prod al-uzza — surchargeables via --db / la variable JL_DILA_DIR.
+DILA_DIR = os.environ.get("JL_DILA_DIR", "/opt/justicelibre/dila")
+
+FONDS = {
+    "legi.db":       ["legi_articles_fts"],
+    "jorf.db":       ["jorf_fts"],
+    "kali.db":       ["kali_fts"],
+    "cnil.db":       ["cnil_fts"],
+    "jade.db":       ["jade_fts"],
+    "judiciaire.db": ["decisions_fts", "cedh_fts", "cjue_fts", "ariane_fts"],
+    "opendata.db":   ["opendata_fts"],
+    "legifrance.db": ["articles_fts"],
+}
+
+
+def _fts_tables(conn: sqlite3.Connection) -> set[str]:
+    rows = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND sql LIKE '%USING fts5%'"
+    ).fetchall()
+    return {r[0] for r in rows}
+
+
+def rebuild_db(path: str, wanted: list[str], dry_run: bool) -> int:
+    if not os.path.exists(path):
+        print(f"  – {path} : absent, skip")
+        return 0
+    conn = sqlite3.connect(path, timeout=300.0)
+    try:
+        present = _fts_tables(conn)
+        done = 0
+        for fts in wanted:
+            if fts not in present:
+                print(f"  – {os.path.basename(path)}:{fts} : table absente, skip")
+                continue
+            if dry_run:
+                print(f"  · {os.path.basename(path)}:{fts} : serait reconstruit")
+                continue
+            t0 = time.monotonic()
+            conn.execute(f"INSERT INTO {fts}({fts}) VALUES('rebuild')")
+            conn.commit()
+            # Vérifie l'intégrité après reconstruction.
+            conn.execute(f"INSERT INTO {fts}({fts}) VALUES('integrity-check')")
+            print(f"  ✓ {os.path.basename(path)}:{fts} "
+                  f"reconstruit + intègre ({time.monotonic() - t0:.1f}s)")
+            done += 1
+        return done
+    finally:
+        conn.close()
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    p.add_argument("--db", help="reconstruire une seule base (chemin complet)")
+    p.add_argument("--dry-run", action="store_true")
+    args = p.parse_args()
+
+    if args.db:
+        name = os.path.basename(args.db)
+        targets = {args.db: FONDS.get(name, [])}
+        if not targets[args.db]:
+            print(f"Base inconnue : {name}. Fonds connus : {', '.join(FONDS)}",
+                  file=sys.stderr)
+            return 2
+    else:
+        targets = {os.path.join(DILA_DIR, name): tabs for name, tabs in FONDS.items()}
+
+    total = 0
+    for path, tabs in targets.items():
+        total += rebuild_db(path, tabs, args.dry_run)
+    print(f"\n{'(dry-run) ' if args.dry_run else ''}{total} index reconstruit(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -18,6 +18,7 @@ run tests/test_search.py
 run tests/test_v2.py
 run tests/test_source_url.py
 run tests/test_citations.py
+run tests/test_fts5_triggers.py
 
 if [[ $INCLUDE_LIVE -eq 1 ]]; then
     echo "(les tests live sont déjà inclus dans test_search.py et test_v2.py)"

--- a/tests/test_fts5_triggers.py
+++ b/tests/test_fts5_triggers.py
@@ -1,0 +1,202 @@
+"""Test suite for FTS5 external-content integrity on re-import.
+
+Verrouille le correctif du bug d'index FTS5 : sur une table external-content
+(content='…'), un `INSERT OR REPLACE` réassigne un nouveau rowid et laissait
+l'ancienne entrée FTS orpheline — recherche corrompue, voire crash
+`fts5: missing row from content table`. Le correctif = triggers _ad/_au +
+`PRAGMA recursive_triggers=ON` sur les connexions d'écriture.
+
+Deux niveaux de test, tous OFFLINE (SQLite en mémoire, aucune base de prod) :
+1. cohérence statique — tout trigger `_ai AFTER INSERT` d'un fichier source
+   doit avoir ses `_ad AFTER DELETE` et `_au AFTER UPDATE` frères ;
+2. comportemental — on rejoue le scénario de ré-importation sur les deux
+   patterns réels (external-content à triggers, et contentless d'opendata) et
+   on prouve l'absence d'orphelin.
+
+Run :
+    python3 -m pytest tests/test_fts5_triggers.py -v
+ou :
+    python3 tests/test_fts5_triggers.py
+"""
+import os
+import re
+import sqlite3
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_HERE)
+
+# Fichiers qui créent des tables FTS5 external-content à triggers.
+TRIGGER_FILES = [
+    "scrape_cedh.py", "scrape_cjue.py", "scrape_ariane.py",
+    "index_dila.py", "scrape_legifrance.py", "parse_dila_bulk.py",
+]
+# Writers dont les connexions doivent activer recursive_triggers.
+WRITER_FILES = TRIGGER_FILES + [
+    "scrape_cedh_gaps.py", "rescrape_cedh.py", "judilibre_sync.py",
+]
+
+
+def _src(name: str) -> str:
+    with open(os.path.join(_ROOT, name), encoding="utf-8") as f:
+        return f.read()
+
+
+def test_every_ai_trigger_has_ad_and_au():
+    """Pour chaque `CREATE TRIGGER … <stem>_ai AFTER INSERT ON <base>`, les
+    triggers `<stem>_ad AFTER DELETE ON <base>` et `<stem>_au AFTER UPDATE ON
+    <base>` doivent exister dans le même fichier."""
+    problems = []
+    ai_re = re.compile(
+        r"CREATE TRIGGER IF NOT EXISTS\s+(\S+?)_ai\s+AFTER INSERT ON\s+(\S+)",
+        re.IGNORECASE,
+    )
+    for name in TRIGGER_FILES:
+        src = _src(name)
+        for stem, base in ai_re.findall(src):
+            for suffix, action in (("_ad", "AFTER DELETE"), ("_au", "AFTER UPDATE")):
+                pat = re.compile(
+                    rf"CREATE TRIGGER IF NOT EXISTS\s+{re.escape(stem)}{suffix}\s+"
+                    rf"{action} ON\s+{re.escape(base)}",
+                    re.IGNORECASE,
+                )
+                if not pat.search(src):
+                    problems.append(f"{name}: {stem}_ai sur {base} sans {stem}{suffix}")
+    assert not problems, "triggers FTS incomplets :\n  " + "\n  ".join(problems)
+
+
+def test_writers_enable_recursive_triggers():
+    """Chaque writer FTS doit activer recursive_triggers (sinon le DELETE
+    implicite d'un INSERT OR REPLACE ne déclenche pas le trigger _ad)."""
+    missing = [
+        name for name in WRITER_FILES
+        if "PRAGMA recursive_triggers=ON" not in _src(name)
+    ]
+    assert not missing, "writers sans recursive_triggers :\n  " + "\n  ".join(missing)
+
+
+# ─── Comportemental : pattern external-content à triggers (cedh) ──────
+
+_CEDH_SCHEMA = """
+CREATE TABLE cedh_decisions(
+    itemid TEXT PRIMARY KEY, docname, ecli, date, doctype,
+    article, conclusion, importance, respondent, text
+);
+CREATE VIRTUAL TABLE cedh_fts USING fts5(
+    itemid UNINDEXED, docname, article, conclusion, text,
+    content='cedh_decisions', content_rowid='rowid'
+);
+CREATE TRIGGER cedh_ai AFTER INSERT ON cedh_decisions BEGIN
+    INSERT INTO cedh_fts(rowid, itemid, docname, article, conclusion, text)
+    VALUES (new.rowid, new.itemid, new.docname, new.article, new.conclusion, new.text);
+END;
+CREATE TRIGGER cedh_ad AFTER DELETE ON cedh_decisions BEGIN
+    INSERT INTO cedh_fts(cedh_fts, rowid, itemid, docname, article, conclusion, text)
+    VALUES ('delete', old.rowid, old.itemid, old.docname, old.article, old.conclusion, old.text);
+END;
+CREATE TRIGGER cedh_au AFTER UPDATE ON cedh_decisions BEGIN
+    INSERT INTO cedh_fts(cedh_fts, rowid, itemid, docname, article, conclusion, text)
+    VALUES ('delete', old.rowid, old.itemid, old.docname, old.article, old.conclusion, old.text);
+    INSERT INTO cedh_fts(rowid, itemid, docname, article, conclusion, text)
+    VALUES (new.rowid, new.itemid, new.docname, new.article, new.conclusion, new.text);
+END;
+"""
+
+
+def test_external_content_no_orphan_on_replace_and_update():
+    conn = sqlite3.connect(":memory:")
+    conn.execute("PRAGMA recursive_triggers=ON")  # indispensable (cf. writers)
+    conn.executescript(_CEDH_SCHEMA)
+    # même itemid ré-importé (INSERT OR REPLACE) puis mis à jour (UPDATE).
+    for t in ("texte_alpha", "texte_beta", "texte_gamma"):
+        conn.execute(
+            "INSERT OR REPLACE INTO cedh_decisions(itemid, docname, article, "
+            "conclusion, text) VALUES('X1','n','a','c',?)", (t,))
+    conn.execute("UPDATE cedh_decisions SET text='texte_delta' WHERE itemid='X1'")
+
+    for stale in ("texte_alpha", "texte_beta", "texte_gamma"):
+        n = conn.execute("SELECT count(*) FROM cedh_fts WHERE cedh_fts MATCH ?",
+                         (stale,)).fetchone()[0]
+        assert n == 0, f"orphelin FTS sur terme périmé {stale!r} : {n} hit(s)"
+    # une recherche qui LIT les colonnes ne doit pas crasher (missing row).
+    rows = conn.execute(
+        "SELECT itemid, text FROM cedh_fts WHERE cedh_fts MATCH 'texte_delta'"
+    ).fetchall()
+    assert rows == [("X1", "texte_delta")], rows
+    # integrity-check natif FTS5.
+    conn.execute("INSERT INTO cedh_fts(cedh_fts) VALUES('integrity-check')")
+
+
+def test_external_content_orphans_without_recursive_triggers():
+    """Contre-preuve : sans le PRAGMA, les orphelins réapparaissent — c'est ce
+    qui rend le PRAGMA indispensable (et pas seulement les triggers)."""
+    conn = sqlite3.connect(":memory:")  # recursive_triggers=OFF (défaut)
+    conn.executescript(_CEDH_SCHEMA)
+    for t in ("alpha", "beta"):
+        conn.execute(
+            "INSERT OR REPLACE INTO cedh_decisions(itemid, docname, article, "
+            "conclusion, text) VALUES('X1','n','a','c',?)", (t,))
+    orphan = conn.execute(
+        "SELECT count(*) FROM cedh_fts WHERE cedh_fts MATCH 'alpha'").fetchone()[0]
+    assert orphan == 1, "le PRAGMA serait inutile — revérifier l'hypothèse du fix"
+
+
+# ─── Comportemental : pattern contentless maintenu à la main (opendata) ──
+
+def test_opendata_contentless_no_orphan_on_reimport():
+    conn = sqlite3.connect(":memory:")
+    conn.executescript("""
+        CREATE TABLE opendata_decisions(id TEXT PRIMARY KEY, juridiction_name,
+            numero_dossier, texte);
+        CREATE VIRTUAL TABLE opendata_fts USING fts5(
+            id UNINDEXED, juridiction, numero_dossier, texte, content='');
+    """)
+
+    def upsert(texte):  # réplique la logique corrigée de download_opendata
+        old = conn.execute(
+            "SELECT rowid, id, juridiction_name, numero_dossier, texte "
+            "FROM opendata_decisions WHERE id = ?", ("D1",)).fetchone()
+        if old and old[4]:
+            conn.execute(
+                "INSERT INTO opendata_fts(opendata_fts, rowid, id, juridiction, "
+                "numero_dossier, texte) VALUES ('delete', ?, ?, ?, ?, ?)", old)
+        conn.execute("INSERT OR REPLACE INTO opendata_decisions"
+                     "(id, juridiction_name, numero_dossier, texte) "
+                     "VALUES('D1','CE','123',?)", (texte,))
+        conn.execute("INSERT OR REPLACE INTO opendata_fts(rowid, id, juridiction, "
+                     "numero_dossier, texte) VALUES "
+                     "((SELECT rowid FROM opendata_decisions WHERE id='D1'),"
+                     "'D1','CE','123',?)", (texte,))
+
+    for t in ("alpha", "beta", "gamma"):
+        upsert(t)
+    for stale in ("alpha", "beta"):
+        n = conn.execute("SELECT count(*) FROM opendata_fts WHERE opendata_fts MATCH ?",
+                         (stale,)).fetchone()[0]
+        assert n == 0, f"orphelin FTS opendata sur {stale!r} : {n}"
+    n = conn.execute("SELECT count(*) FROM opendata_fts WHERE opendata_fts MATCH 'gamma'").fetchone()[0]
+    assert n == 1, n
+
+
+# ─── Runner sans pytest ──────────────────────────────────────────
+
+if __name__ == "__main__":
+    tests = [
+        ("chaque _ai a _ad + _au",                 test_every_ai_trigger_has_ad_and_au),
+        ("writers activent recursive_triggers",    test_writers_enable_recursive_triggers),
+        ("external-content sans orphelin",         test_external_content_no_orphan_on_replace_and_update),
+        ("contre-preuve sans le PRAGMA",           test_external_content_orphans_without_recursive_triggers),
+        ("opendata contentless sans orphelin",     test_opendata_contentless_no_orphan_on_reimport),
+    ]
+    failed = 0
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"  ✓ {name}")
+        except AssertionError as e:
+            print(f"  ✗ {name}")
+            print(f"      {e}")
+            failed += 1
+    if failed:
+        sys.exit(1)
+    print(f"\nAll {len(tests)} tests passed.")


### PR DESCRIPTION
## Le bug (prouvé)

Toutes les bases FTS5 en external-content (`content='…'`) n'avaient qu'un trigger `_ai AFTER INSERT`. Or **tout le pipeline écrit en `INSERT OR REPLACE`** — qui réassigne un nouveau rowid à chaque ré-importation. L'ancienne entrée FTS, pointant l'ancien rowid, n'était jamais supprimée → **index désynchronisé** : résultats de recherche dupliqués/faux, et surtout **crash** sur une recherche qui lit les colonnes de contenu :

```
sqlite3.DatabaseError: fts5: missing row 1 from content table 'main'.'cedh_decisions'
```

Reproduit sur SQLite en mémoire (2× `INSERT OR REPLACE` du même id → la recherche sur le texte périmé renvoie encore une ligne, et un `SELECT itemid, text … MATCH` plante). Deux chemins d'écriture minoritaires étaient aussi cassés autrement : le `UPDATE … SET text` de `rescrape_cedh.py` et le `DELETE`+`INSERT` de `judilibre_sync.py` ne réindexaient jamais rien (aucun trigger DELETE/UPDATE).

## Le correctif — trois mécanismes, un par pattern

1. **Triggers `_ad` (AFTER DELETE) + `_au` (AFTER UPDATE)** sur les 10 tables external-content (`parse_dila_bulk.py` : legi/jorf/juris/kali/cnil ; `index_dila.py` ; `scrape_legifrance.py` ; `scrape_cedh/cjue/ariane.py`), colonnes rigoureusement alignées sur le `_ai` existant. Corrige aussi les chemins DELETE explicite (judilibre) et UPDATE (rescrape) — qui déclenchent désormais `_ad`/`_au` directement.

2. **`PRAGMA recursive_triggers=ON`** sur les 13 connexions d'écriture. Point subtil mais décisif : avec le défaut SQLite `recursive_triggers=OFF`, le DELETE **implicite** d'un `INSERT OR REPLACE` **ne déclenche pas** `_ad`. Sans ce PRAGMA, les triggers seuls ne corrigent pas le chemin REPLACE (le chemin dominant). Le test inclut une **contre-preuve** qui le démontre.

3. **`download_opendata.py`** utilise un FTS *contentless* (`content=''`) maintenu à la main, pas de triggers : purge explicite de l'ancienne entrée (commande `'delete'` + valeurs exactes) avant le `REPLACE` qui change le rowid. Même symptôme, mécanisme différent — reproduit et corrigé aussi.

## Migration des bases existantes

Les triggers étant en `CREATE … IF NOT EXISTS`, ils s'installent au prochain run et rendent les écritures **futures** correctes. Pour purger les orphelins **déjà accumulés**, `scripts/rebuild_fts.py` (idempotent, `--dry-run`) reconstruit chaque index une fois après déploiement — à lancer hors des heures de parse (coûteux sur legi/jade).

## Vérification

`tests/test_fts5_triggers.py` (offline, dans `run_all.sh`) :
- **cohérence statique** : tout `_ai` d'un fichier a ses `_ad`/`_au` frères ; tout writer active `recursive_triggers` — verrouille la non-régression future ;
- **comportemental** : rejoue la ré-importation sur les deux patterns (external-content et contentless) et prouve l'absence d'orphelin + l'`integrity-check` FTS5 natif ;
- **contre-preuve** : sans le PRAGMA, l'orphelin réapparaît (justifie le volet 2).

`py_compile` OK sur les 12 fichiers ; `test_source_url` / `test_citations` toujours verts.

## Portée

Autoportante (basée sur `main`). Ne touche que le schéma FTS + le PRAGMA de connexion + la purge opendata — aucune logique de parsing/scraping applicative modifiée.
