### PR TITLE
Hygiène scrapers : curl -f, imports morts, User-Agent, .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 test_mcp_client.py
 web/logo-preview.html
 web/version.json
+.DS_Store

--- a/rescrape_cedh.py
+++ b/rescrape_cedh.py
@@ -11,7 +11,6 @@ import re
 import sqlite3
 import sys
 import time
-from urllib.parse import quote
 
 import httpx
 

--- a/scrape_ariane.py
+++ b/scrape_ariane.py
@@ -9,7 +9,6 @@ Circuit breaker : si N erreurs consécutives, on stoppe le script.
 """
 import html as _html
 import itertools
-import os
 import re
 import sqlite3
 import sys

--- a/scrape_cedh_gaps.py
+++ b/scrape_cedh_gaps.py
@@ -17,7 +17,7 @@ sys.stdout.reconfigure(line_buffering=True)
 DB_PATH = "/opt/justicelibre/dila/judiciaire.db"
 BASE = "https://hudoc.echr.coe.int"
 BATCH = 500  # list-only batch, pas de fetch_text dans la boucle de listing
-USER_AGENT = "justicelibre.org/1.0 (gap-filler)"
+USER_AGENT = "justicelibre.org/1.0 (open data scraper, contact: dahliyaal@justicelibre.org)"
 QUERY_BASE = (
     'contentsitename=ECHR AND '
     '(NOT (doctype=PR OR doctype=HFCOMOLD OR doctype=HECOMOLD)) AND '

--- a/update_dila.sh
+++ b/update_dila.sh
@@ -15,7 +15,7 @@ echo "$(date) - Starting DILA update"
 LATEST_CASS=$(curl -s "https://echanges.dila.gouv.fr/OPENDATA/CASS/" | grep -oP 'CASS_[0-9]{8}-[0-9]+\.tar\.gz' | sort -u | tail -1)
 if [ -n "$LATEST_CASS" ] && [ ! -f "$INCREMENTS_DIR/$LATEST_CASS" ]; then
     echo "Downloading $LATEST_CASS..."
-    curl -L -s -o "$INCREMENTS_DIR/$LATEST_CASS" "https://echanges.dila.gouv.fr/OPENDATA/CASS/$LATEST_CASS"
+    curl -fL -s -o "$INCREMENTS_DIR/$LATEST_CASS" "https://echanges.dila.gouv.fr/OPENDATA/CASS/$LATEST_CASS"
     mkdir -p "$DILA_DIR/new_cass"
     tar xzf "$INCREMENTS_DIR/$LATEST_CASS" -C "$DILA_DIR/new_cass"
     echo "Extracted $(find $DILA_DIR/new_cass -name '*.xml' | wc -l) CASS XML files"
@@ -30,7 +30,7 @@ fi
 LATEST_CAPP=$(curl -s "https://echanges.dila.gouv.fr/OPENDATA/CAPP/" | grep -oP 'CAPP_[0-9]{8}-[0-9]+\.tar\.gz' | sort -u | tail -1)
 if [ -n "$LATEST_CAPP" ] && [ ! -f "$INCREMENTS_DIR/$LATEST_CAPP" ]; then
     echo "Downloading $LATEST_CAPP..."
-    curl -L -s -o "$INCREMENTS_DIR/$LATEST_CAPP" "https://echanges.dila.gouv.fr/OPENDATA/CAPP/$LATEST_CAPP"
+    curl -fL -s -o "$INCREMENTS_DIR/$LATEST_CAPP" "https://echanges.dila.gouv.fr/OPENDATA/CAPP/$LATEST_CAPP"
     mkdir -p "$DILA_DIR/new_capp"
     tar xzf "$INCREMENTS_DIR/$LATEST_CAPP" -C "$DILA_DIR/new_capp"
     echo "Extracted $(find $DILA_DIR/new_capp -name '*.xml' | wc -l) CAPP XML files"
@@ -44,7 +44,7 @@ fi
 LATEST_INCA=$(curl -s "https://echanges.dila.gouv.fr/OPENDATA/INCA/" | grep -oP 'INCA_[0-9]{8}-[0-9]+\.tar\.gz' | sort -u | tail -1)
 if [ -n "$LATEST_INCA" ] && [ ! -f "$INCREMENTS_DIR/$LATEST_INCA" ]; then
     echo "Downloading $LATEST_INCA..."
-    curl -L -s -o "$INCREMENTS_DIR/$LATEST_INCA" "https://echanges.dila.gouv.fr/OPENDATA/INCA/$LATEST_INCA"
+    curl -fL -s -o "$INCREMENTS_DIR/$LATEST_INCA" "https://echanges.dila.gouv.fr/OPENDATA/INCA/$LATEST_INCA"
     mkdir -p "$DILA_DIR/new_inca"
     tar xzf "$INCREMENTS_DIR/$LATEST_INCA" -C "$DILA_DIR/new_inca"
     echo "Extracted $(find $DILA_DIR/new_inca -name '*.xml' | wc -l) INCA XML files"


### PR DESCRIPTION
Micro-fixes issus de l'audit des scrapers — **aucun changement de comportement fonctionnel**, tout est autoportant.

- **`update_dila.sh`** : ajoute `-f` aux 3 `curl` de téléchargement. Sans lui, une réponse HTTP 4xx/5xx est enregistrée telle quelle comme fichier `.tar.gz`, puis `tar xzf` échoue sur une page d'erreur. Aligne le comportement sur les autres scripts qui utilisent déjà `curl -sf`. (Les `curl` de *listing* restent en `-s` : leur échec produit un `LATEST` vide déjà géré par le garde `if`.)
- **`scrape_ariane.py`** : retire `import os` inutilisé.
- **`rescrape_cedh.py`** : retire `from urllib.parse import quote` inutilisé.
- **`scrape_cedh_gaps.py`** : User-Agent aligné sur les autres scrapers (`... contact: dahliyaal@justicelibre.org`) au lieu de `gap-filler` sans contact — politesse cohérente envers HUDOC.
- **`.gitignore`** : ajoute `.DS_Store`.

Vérifié : `py_compile` sur les 3 fichiers Python, `bash -n update_dila.sh`.

À noter (hors périmètre, non touché ici) : `export_piste.py` est du code mort superseded par `export_piste_v2.py` — suppression laissée à votre appréciation.
