### PR TITLE
SSR : corrige XSS stockée (H1/href) + JSON-LD invalide sur 3M pages

### DIFF
--- a/ssr.py
+++ b/ssr.py
@@ -272,14 +272,17 @@ def _lang_warning(text_lang: str, decision_id: str, source: str) -> str:
     if lang == "fr" or not lang:
         return ""
     lang_name = _LANG_NAMES.get(lang, lang)
-    deepl_url = f"https://www.deepl.com/translator#{lang}/fr/"
+    # lang vient de la DB (HUDOC/curia), non validé : on ne l'injecte dans l'URL
+    # que s'il est whitelisté, sinon fallback 'en' — et on esc() par sécurité.
+    deepl_lang = lang if lang in _LANG_NAMES else "en"
+    deepl_url = f"https://www.deepl.com/translator#{deepl_lang}/fr/"
     return (
         '<div class="lang-warning">'
         '<div class="lang-warning__inner">'
         f'<strong>Texte original en {esc(lang_name)}.</strong> '
         f"La version française de cette décision n'a pas été publiée. "
         "Vous pouvez le traduire via un service externe : "
-        f'<a href="{deepl_url}" target="_blank" rel="external noopener">DeepL ↗</a> '
+        f'<a href="{esc(deepl_url)}" target="_blank" rel="external noopener">DeepL ↗</a> '
         "(coller le texte ci-dessous)."
         '</div>'
         '</div>'
@@ -310,7 +313,7 @@ def _official_source_button(decision_id: str) -> str:
     label, url = pat
     return (
         '<div class="source-cta">'
-        '<a class="btn-source" href="' + url + '" target="_blank" rel="external noopener nofollow">'
+        '<a class="btn-source" href="' + esc(url) + '" target="_blank" rel="external noopener nofollow">'
         '<span class="btn-source-label">Voir sur ' + label + '</span>'
         '<span class="btn-source-arrow">→</span>'
         '</a>'
@@ -638,6 +641,23 @@ def esc(s: str) -> str:
     return html.escape(s or "", quote=True)
 
 
+def _jsonld_embed(obj) -> str:
+    """Sérialise un objet en JSON valide et sûr pour <script type="application/ld+json">.
+
+    Contexte <script> = raw text : html.escape() y produirait &quot; etc. que le
+    parseur JSON de Google ne décode pas (structured data ignorée). On échappe
+    donc <, > et & en séquences unicode JSON (\\u003c ...) : JSON valide ET aucun
+    </script> ne peut fermer la balise.
+    """
+    import json as _json
+    return (
+        _json.dumps(obj, ensure_ascii=False)
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+    )
+
+
 def _strip(text: str, n: int = 200) -> str:
     """Premiers `n` caractères de texte propre pour <meta description>."""
     if not text:
@@ -686,9 +706,11 @@ def render_decision(source: str, decision_id: str, data: dict) -> str:
 
     # Titre H1 : juridiction en kicker, le n° + date en gros
     main_id = f"n° {numero}" if numero else titre_brut or f"Décision {decision_id}"
-    title_h1 = main_id
+    # main_id = numero / titre_brut / decision_id BRUTS (DB) → esc() obligatoire en H1.
+    main_id_html = f"n° {esc(numero)}" if numero else esc(titre_brut) or f"Décision {esc(decision_id)}"
+    title_h1 = main_id_html
     if date:
-        title_h1 = f"{main_id} <em>· {esc(_format_fr_date(date))}</em>"
+        title_h1 = f"{main_id_html} <em>· {esc(_format_fr_date(date))}</em>"
     title_h1_plain = f"{main_id} · {_format_fr_date(date)}" if date else main_id
     title_seo = f"{juri or main_id}, {numero or ''} {(_format_fr_date(date) or '').strip()} -{SITE_NAME}".strip()
 
@@ -740,8 +762,7 @@ def render_decision(source: str, decision_id: str, data: dict) -> str:
         "sameAs": source_url or None,
     }
     jsonld_clean = {k: v for k, v in jsonld.items() if v is not None}
-    import json as _json
-    jsonld_str = esc(_json.dumps(jsonld_clean, ensure_ascii=False))
+    jsonld_str = _jsonld_embed(jsonld_clean)
 
     rows = []
     if juri: rows.append(("Juridiction", esc(juri)))
@@ -769,7 +790,7 @@ def render_decision(source: str, decision_id: str, data: dict) -> str:
         meta_html += (
             f'<tr class="source-row"><th>Source officielle</th>'
             f'<td><a href="{esc(source_url)}" target="_blank" rel="external noopener">'
-            f'{_source_host(source_url)} ↗</a></td></tr>'
+            f'{esc(_source_host(source_url))} ↗</a></td></tr>'
         )
     bulk_label, bulk_url = BULK_SOURCES.get(source, ("", ""))
     if bulk_url:
@@ -892,8 +913,7 @@ def render_law(code: str, num: str, data: dict) -> str:
         "sameAs": source_url or None,
     }
     jsonld_clean = {k: v for k, v in jsonld.items() if v is not None}
-    import json as _json
-    jsonld_str = esc(_json.dumps(jsonld_clean, ensure_ascii=False))
+    jsonld_str = _jsonld_embed(jsonld_clean)
 
     rows = [("Code", esc(code_label)), ("État", esc(etat or "-"))]
     if date_debut: rows.append(("En vigueur depuis", esc(_format_fr_date(date_debut))))
@@ -907,7 +927,7 @@ def render_law(code: str, num: str, data: dict) -> str:
         meta_html += (
             f'<tr class="source-row"><th>Source officielle</th>'
             f'<td><a href="{esc(source_url)}" target="_blank" rel="external noopener">'
-            f'{_source_host(source_url)} ↗</a></td></tr>'
+            f'{esc(_source_host(source_url))} ↗</a></td></tr>'
         )
     # Bulk LEGI pour les articles de loi (toujours pareil)
     meta_html += (
@@ -948,7 +968,7 @@ def render_law(code: str, num: str, data: dict) -> str:
 <main class="wrap">
   <div class="kicker">{esc(code_label)}</div>
   <h1>Article <em>{esc(num)}</em></h1>
-  <p class="subline">Article{(' en vigueur depuis le ' + _format_fr_date(date_debut)) if date_debut else ''}.</p>
+  <p class="subline">Article{(' en vigueur depuis le ' + esc(_format_fr_date(date_debut))) if date_debut else ''}.</p>
   <table class="meta-table">{meta_html}</table>
   <article>{text_html}{nota_html}</article>
   <footer class="page-footer">

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -18,6 +18,7 @@ run tests/test_search.py
 run tests/test_v2.py
 run tests/test_source_url.py
 run tests/test_citations.py
+run tests/test_ssr_escaping.py
 
 if [[ $INCLUDE_LIVE -eq 1 ]]; then
     echo "(les tests live sont déjà inclus dans test_search.py et test_v2.py)"

--- a/tests/test_ssr_escaping.py
+++ b/tests/test_ssr_escaping.py
@@ -1,0 +1,131 @@
+"""Test suite for SSR HTML output escaping (anti-XSS + JSON-LD valide).
+
+ssr.py génère le HTML de ~3M pages publiques depuis des données parsées
+(DILA/HUDOC/curia) — donc potentiellement hostiles. Ce test injecte des
+charges hostiles dans render_decision / render_law (qui prennent un
+`data: dict`, donc OFFLINE, sans base) et vérifie :
+  1. aucune donnée hostile ne ressort exécutable (pas de <script> non
+     JSON-LD contenant la charge, pas d'attribut on*/javascript:) ;
+  2. le JSON-LD reste du JSON PARSABLE (sur-échappement html.escape
+     cassait la structured data sur les 3M pages) ;
+  3. `_jsonld_embed` empêche le breakout `</script>`.
+
+Run :
+    python3 -m pytest tests/test_ssr_escaping.py -v
+ou :
+    python3 tests/test_ssr_escaping.py
+"""
+import html.parser
+import json
+import os
+import re
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(_HERE))
+
+import ssr  # noqa: E402
+
+_XSS = "<script>alert(1)</script>"
+_ATTR = '"><img src=x onerror=alert(1)>'
+
+
+class _Sniffer(html.parser.HTMLParser):
+    """Repère les <script> exécutables (hors JSON-LD) et les attributs
+    événementiels — ce qui rendrait une charge hostile exécutable."""
+
+    def __init__(self):
+        super().__init__()
+        self.exec_scripts, self.event_attrs = [], []
+        self._in, self._buf = False, ""
+
+    def handle_starttag(self, tag, attrs):
+        d = dict(attrs)
+        if tag == "script" and d.get("type") != "application/ld+json":
+            self._in, self._buf = True, ""
+        for k, v in attrs:
+            if k.startswith("on") or (v and v.strip().lower().startswith("javascript:")):
+                self.event_attrs.append((tag, k, v))
+
+    def handle_endtag(self, tag):
+        if tag == "script" and self._in:
+            self._in = False
+            if self._buf.strip():
+                self.exec_scripts.append(self._buf)
+
+    def handle_data(self, data):
+        if self._in:
+            self._buf += data
+
+
+def _assert_no_xss(htmlout: str, label: str):
+    s = _Sniffer()
+    s.feed(htmlout)
+    exe = [x for x in s.exec_scripts if "alert(1)" in x]
+    assert not exe, f"{label}: {len(exe)} <script> exécutable(s) injecté(s)"
+    assert not s.event_attrs, f"{label}: attribut événementiel injecté : {s.event_attrs[:3]}"
+    # Le JSON-LD doit rester parsable.
+    for block in re.findall(
+        r'<script type="application/ld\+json">(.*?)</script>', htmlout, re.S
+    ):
+        json.loads(block)  # lève si invalide
+
+
+def test_render_decision_no_xss():
+    data = {
+        "numero": _ATTR, "titre": _XSS, "juridiction": _ATTR, "ecli": _XSS,
+        "date": "2023-05-04", "solution": _ATTR, "text": "corps " + _XSS,
+        "abstrats": "", "sommaire": "",
+        "text_lang": 'en"><script>alert(1)</script>',
+        "source_url": 'http://evil"><script>alert(1)</script>.com',
+    }
+    _assert_no_xss(ssr.render_decision("cedh", "001-249914", data), "render_decision")
+
+
+def test_render_law_no_xss():
+    data = {
+        "num": _ATTR, "code": "CC", "texte": "loi " + _XSS, "etat": "VIGUEUR",
+        "nota": _XSS, "date_debut": '2016-10-01"><script>alert(1)</script>',
+        "source_url": 'http://x"><script>alert(1)</script>',
+    }
+    _assert_no_xss(ssr.render_law("CC", "1128", data), "render_law")
+
+
+def test_jsonld_embed_valid_and_no_breakout():
+    embedded = ssr._jsonld_embed(
+        {"name": "</script><script>alert(1)</script>", "x": "a < b & c > d"}
+    )
+    assert "</script>" not in embedded, "breakout </script> possible dans le JSON-LD"
+    # json.loads décode les \\uXXXX → doit reparser à l'identique.
+    assert json.loads(embedded)["name"] == "</script><script>alert(1)</script>"
+
+
+def test_jsonld_not_html_over_escaped():
+    """Garde-fou anti-régression : le JSON-LD ne doit PAS contenir d'entités
+    HTML (&quot; etc.) qui casseraient JSON.parse côté Google."""
+    embedded = ssr._jsonld_embed({"name": 'Décision "X" & autres'})
+    assert "&quot;" not in embedded and "&amp;" not in embedded, \
+        "sur-échappement html.escape réintroduit (structured data cassée)"
+    json.loads(embedded)
+
+
+# ─── Runner sans pytest ──────────────────────────────────────────
+
+if __name__ == "__main__":
+    tests = [
+        ("render_decision sans XSS",        test_render_decision_no_xss),
+        ("render_law sans XSS",             test_render_law_no_xss),
+        ("_jsonld_embed valide + no breakout", test_jsonld_embed_valid_and_no_breakout),
+        ("JSON-LD pas sur-échappé",         test_jsonld_not_html_over_escaped),
+    ]
+    failed = 0
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"  ✓ {name}")
+        except AssertionError as e:
+            print(f"  ✗ {name}\n      {e}")
+            failed += 1
+    if failed:
+        sys.exit(1)
+    print(f"\nAll {len(tests)} tests passed.")


### PR DESCRIPTION
Deux problèmes dans `ssr.py` (qui génère le HTML de ~3M pages **publiques** depuis des données parsées DILA/HUDOC/curia), chacun **reproduit et vérifié**.

## 🔴 XSS stockée

Le H1 des décisions injectait `numero` / `titre` / `decision_id` **bruts** de la base (`main_id`, `ssr.py:812`) sans `esc()` — la date adjacente était échappée, pas eux. Un titre contenant `<script>` ou `"><img onerror=…>` s'exécutait sur la page. Deux sinks jumeaux : l'URL DeepL (`text_lang` de la DB, non validé, dans un `href`) et le **texte** du lien source (`_source_host(source_url)`, échappé côté `href` mais pas côté texte — trouvé par le balayage de complétude, au-delà des sinks initiaux).

**Corrigé** : `esc()` sur toutes ces données ; `deepl` whitelisté sur `_LANG_NAMES` (fallback `en`). Les usages bruts restants de `main_id` (`title_seo`, `title_h1_plain`) sont tous ré-échappés à la sortie (`<title>`, og:/twitter:) ou passent par le JSON-LD sûr — vérifié, aucun sink déplacé.

## 🟠 JSON-LD invalide sur les 3M pages (SEO)

`jsonld_str = esc(json.dumps(...))` était injecté dans `<script type="application/ld+json">`. En contexte `<script>` (raw text), `html.escape` produit `&quot;`/`&amp;` que le parseur JSON de Google **ne décode pas** → `JSON.parse` échoue → structured data **ignorée sur les 3M pages**. Pour un projet dont l'indexation est la raison d'être, c'est une régression majeure. Piège : on ne peut pas simplement retirer `esc()`, sinon un titre contenant `</script>` ferait un breakout XSS.

**Corrigé** via un helper `_jsonld_embed` qui échappe `<` `>` `&` en séquences unicode JSON (`<`…) : **JSON valide** *et* aucun `</script>` ne peut fermer la balise.

## Vérification

`tests/test_ssr_escaping.py` (offline, dans `run_all.sh`) : `render_decision`/`render_law` rendus avec des charges hostiles (`<script>`, `"><img onerror>`, `text_lang` cassant l'attribut), puis parsés avec `html.parser` → **zéro `<script>` exécutable, zéro attribut événementiel** ; le JSON-LD reparse ; `_jsonld_embed` prouvé sans breakout et sans sur-échappement. `py_compile` OK ; `test_source_url`/`test_citations` toujours verts.

Méthode : un balayage exhaustif de `ssr.py` a d'abord recensé **tous** les points données→HTML (par contexte texte / attribut / script) pour garantir la complétude — un fix sécurité partiel ne vaut rien. 2 sinks trouvés au-delà des 3 initiaux.

## Portée

Autoportante (basée sur `main`). Ne touche que l'échappement de sortie de `ssr.py` — aucune logique de rendu ni le corps de décision (déjà protégé par `linkify`).
