### PR TITLE
CI : GitHub Actions (tests hors ligne + validation server.json)

### DIFF
--- a/.github/scripts/validate_server_json.py
+++ b/.github/scripts/validate_server_json.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Valide server.json contre le schéma officiel du MCP registry.
+
+Lancé en CI. Échec si le JSON est invalide ou ne respecte pas le schéma
+déclaré dans son champ $schema. Le schéma est récupéré en ligne ; en cas
+d'indisponibilité réseau, on valide au moins que le JSON est bien formé
+et porte les champs obligatoires (dégradation gracieuse, jamais un faux
+échec pour un souci réseau).
+"""
+import json
+import sys
+import urllib.request
+from pathlib import Path
+
+doc = json.loads(Path("server.json").read_text(encoding="utf-8"))
+schema_url = doc.get("$schema")
+print(f"server.json chargé — {len(doc.get('tools', []))} tools, $schema={schema_url}")
+
+if not schema_url:
+    print("ERREUR : champ $schema absent de server.json", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    with urllib.request.urlopen(schema_url, timeout=15) as r:
+        schema = json.loads(r.read())
+except Exception as e:  # réseau indisponible → validation minimale
+    print(f"[schéma inaccessible : {e}] — validation minimale (champs requis)")
+    for field in ("name", "description", "version", "tools"):
+        if field not in doc:
+            print(f"ERREUR : champ requis manquant : {field}", file=sys.stderr)
+            sys.exit(1)
+    print("OK (validation minimale)")
+    sys.exit(0)
+
+import jsonschema
+jsonschema.validate(doc, schema)
+print("OK — server.json valide contre le schéma officiel du registry.")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  tests:
+    name: Tests hors ligne (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install runtime deps
+        run: pip install -r requirements.txt
+      - name: Run offline test suite
+        run: bash tests/run_all.sh --offline
+
+  schema:
+    name: Validation server.json (schéma MCP registry)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install jsonschema
+        run: pip install jsonschema
+      - name: Validate server.json against the official registry schema
+        run: python .github/scripts/validate_server_json.py

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
-# Lance tous les tests de régression locaux (sans live API).
-# Usage : tests/run_all.sh
-# Pour inclure les tests live : tests/run_all.sh --live
+# Lance les tests de régression locaux.
+# Usage :
+#   tests/run_all.sh            # tout (offline + tests qui tapent la prod live)
+#   tests/run_all.sh --offline  # uniquement les tests sans réseau (utilisé par la CI)
 set -e
 cd "$(dirname "$0")/.."
 
-INCLUDE_LIVE=0
-[[ "$1" == "--live" ]] && INCLUDE_LIVE=1
+OFFLINE_ONLY=0
+[[ "$1" == "--offline" ]] && OFFLINE_ONLY=1
 
 run() {
     echo "=== $1 ==="
@@ -14,8 +15,7 @@ run() {
     echo
 }
 
-run tests/test_search.py
-run tests/test_v2.py
+# Tests SANS réseau ni base de prod (déterministes → gate de CI).
 run tests/test_source_url.py
 run tests/test_citations.py
 run tests/test_ssr_escaping.py
@@ -24,8 +24,13 @@ run tests/test_fts5_triggers.py
 run tests/test_prompts_resources.py
 run tests/test_error_contract.py
 
-if [[ $INCLUDE_LIVE -eq 1 ]]; then
-    echo "(les tests live sont déjà inclus dans test_search.py et test_v2.py)"
+# Tests qui interrogent la prod live (justicelibre.org) : à ne pas lancer en
+# CI (flaky + charge le serveur). Skippés avec --offline.
+if [[ $OFFLINE_ONLY -eq 0 ]]; then
+    run tests/test_search.py
+    run tests/test_v2.py
+else
+    echo "(--offline : test_search.py et test_v2.py skippés — ils tapent la prod live)"
 fi
 
 echo "✓ Tous les tests passent."


### PR DESCRIPTION
Première PR de la « saison 2 » évoquée dans #11 : une CI, pour rendre vérifiables en continu les contributions suivantes (et remplacer les backup-tags manuels par un vrai filet).

## Ce que ça fait

Sur chaque `push`/`pull_request` vers `main` :
- **job `tests`** (matrice Python **3.11 / 3.12**) : lance la suite de tests **sans réseau ni base de prod** via `tests/run_all.sh --offline` — 7 fichiers déterministes (`test_source_url`, `test_citations`, `test_ssr_escaping`, `test_annotations`, `test_fts5_triggers`, `test_prompts_resources`, `test_error_contract`) ;
- **job `schema`** : valide `server.json` contre le schéma officiel du MCP registry (récupéré en ligne, avec dégradation gracieuse en validation minimale si le schéma est injoignable — jamais un faux rouge pour un souci réseau).

`run_all.sh` gagne un mode `--offline` (entrée partagée CI / dev local). Le comportement par défaut (`tests/run_all.sh` sans argument) est inchangé : il lance tout.

## Choix de périmètre

`test_search.py` et `test_v2.py` sont **exclus de la CI** : ils interrogent la prod live (`justicelibre.org`) — donc flaky (dépendants de la dispo et des données de prod) et ils chargeraient votre serveur à chaque run. Ils restent lancés par `run_all.sh` sans `--offline`.

## ⚠️ Heads-up (non corrigé ici, hors périmètre CI)

En cadrant la CI, un test **offline** existant échoue sur `main` : `test_v2.py::test_warehouse_code_mapping` → *« warehouse manque le code `CCom2` »*. Le code `CCom2` a été ajouté à `legi.py` (votre commit « +50 codes LEGI ») mais **pas au mapping `CODE_TO_LEGITEXT` de `warehouse_server.py`** — donc `get_law_article(code="CCom2", …)` ne résout pas. C'est un vrai bug de dérive, dans votre domaine (le mapping warehouse) : je vous le **signale** sans le corriger ici pour garder cette PR strictement scopée sur la CI. Une fois `CCom2` synchronisé côté warehouse, la partie offline de `test_v2` pourra rejoindre le gate CI.

## Vérification

Les deux jobs sont **verts en local sur Python 3.11 et 3.12** ; `server.json` valide contre le schéma `2025-12-11`. YAML du workflow vérifié.

## Suite

Idéalement, activer la **protection de branche** sur `main` (CI verte requise pour merger) — c'est le vrai levier « trunk-based » sans lourdeur. Ça se règle côté paramètres du repo, à votre main.
