### PR TITLE
Onboarding : requirements complet (lxml, unidecode) + .env.example + docstring server.py

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,36 @@
+# JusticeLibre — variables d'environnement. Copier en `.env` (gitignoré) et
+# renseigner selon les composants qu'on fait tourner. Chargé automatiquement
+# par les scripts PISTE (export_piste*.py, scrape_legifrance.py) ; les autres
+# lisent directement l'environnement du process.
+#
+# La plupart ont un défaut interne (le chemin de prod) — un contributeur ne les
+# renseigne que pour pointer ses propres bases/services en local.
+
+# ── Serveur MCP ───────────────────────────────────────────────────────────
+# Répertoire des bases SQLite DILA (jade, legi, jorf, kali, cnil, judiciaire…).
+# Défaut interne : /opt/justicelibre/dila
+JL_DILA_DIR=/opt/justicelibre/dila
+# Base du thésaurus juridique FR. Défaut interne : thesaurus_fr.db à la racine.
+THESAURUS_DB=./thesaurus_fr.db
+
+# ── Client du warehouse (sources/warehouse.py) ────────────────────────────
+# URL du service warehouse HTTP qui expose les bases. Défaut interne :
+# http://46.224.173.253:8001
+JL_WAREHOUSE_URL=http://127.0.0.1:8001
+# Fichier contenant la clé d'API du warehouse (>= 32 caractères, perms 0600).
+JL_WAREHOUSE_KEY_FILE=/etc/justicelibre/warehouse.key
+
+# ── Serveur warehouse (warehouse/warehouse_server.py) ─────────────────────
+JL_WAREHOUSE_DB_DIR=/opt/justicelibre/dila
+JL_WAREHOUSE_HOST=127.0.0.1
+JL_WAREHOUSE_PORT=8001
+
+# ── API PISTE / Judilibre (optionnel — décisions judiciaires récentes) ─────
+# Identifiants OAuth2 gratuits obtenus sur https://piste.gouv.fr
+# NE JAMAIS committer ces valeurs (le .env est gitignoré).
+PISTE_CLIENT_ID=
+PISTE_CLIENT_SECRET=
+
+# ── Pipeline annuaire (scripts annuaire/) ─────────────────────────────────
+ANNUAIRE_SRC=
+ANNUAIRE_REPO=

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,15 @@
-# JusticeLibre — dépendances du serveur MCP (server.py) et des serveurs
-# annexes (token_server.py, ssr.py, search_api.py : stdlib + httpx).
-# Python >= 3.10 requis par le SDK mcp.
+# JusticeLibre — dépendances Python. Python >= 3.10 (requis par le SDK mcp).
+# Installe tout ce qu'il faut pour faire tourner le serveur MCP ET reconstruire
+# les bases depuis les bulks DILA (chemin d'auto-hébergement du README).
+
+# ── Serveur MCP + serveurs annexes (token_server.py, ssr.py, search_api.py) ──
 mcp>=1.8
 httpx>=0.27
+
+# ── Pipeline ETL / auto-hébergement (parse_dila_bulk.py, scripts/build_thesaurus_db.py) ──
+lxml>=5.0        # parsing des bulks XML DILA (sans lui : ModuleNotFoundError sur parse_dila_bulk)
+
+# ── Normalisation des accents (thésaurus) ──
+# Optionnel au runtime (thesaurus_engine.py a un fallback intégré si absent),
+# mais requis pour reconstruire le thésaurus (scripts/build_thesaurus_db.py).
+unidecode>=1.3

--- a/server.py
+++ b/server.py
@@ -1,19 +1,22 @@
-"""justicelibre — MCP server exposing free access to French administrative
-case law.
+"""justicelibre — serveur MCP d'accès libre à la jurisprudence et au droit
+positif français et européen.
 
-Two data sources, both zero-auth, legally redistributable under Licence
-Ouverte 2.0:
+Expose ~31 tools sur ~3,3 M décisions de justice + ~1,5 M articles de loi
+consolidés (versions historiques) + textes annexes (JORF/KALI/CNIL) :
+Cour de cassation, cours d'appel, Conseil constitutionnel, Conseil d'État,
+CAA, TA, Cour EDH, CJUE. Données zéro-auth, redistribuables sous Licence
+Ouverte 2.0.
 
-  - opendata.justice-administrative.fr (hidden Elasticsearch) — covers
-    Conseil d'État, 9 cours administratives d'appel, and 40 tribunaux
-    administratifs including overseas. Roughly 1,050,000 decisions as of
-    April 2026.
+Sources agrégées (cf. `sources/`) : bulks DILA en local (SQLite + FTS5
+BM25), ArianeWeb/Sinequa (CE), HUDOC (CEDH), EUR-Lex (CJUE), et
+optionnellement PISTE/Judilibre (OAuth2) pour les décisions récentes.
 
-  - conseil-etat.fr/xsearch (ArianeWeb Sinequa) — richest index for Conseil
-    d'État decisions of jurisprudential interest (~270k with highlights).
+Transports :
+    python3 server.py            # stdio (Claude Desktop, Cursor…)
+    python3 server.py http       # Streamable HTTP (Claude.ai, connecteurs)
 
-Phase A: stdio transport, run locally via `mcp dev server.py` or wire it
-into Claude Desktop / Cursor / any MCP client.
+Point d'entrée : le tool `search_all` (recherche fédérée) ; `about_justicelibre`
+détaille la cartographie complète des sources et des identifiants.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
Premiers quick wins de la RFC #13 (aucun enjeu de direction, zéro risque runtime) : rendre l'onboarding honnête.

- **`requirements.txt`** oubliait **`lxml`** (requis par `parse_dila_bulk.py` et `scripts/build_thesaurus_db.py` → `ModuleNotFoundError` pour tout self-hoster qui reconstruit les bases) et **`unidecode`** (requis par `build_thesaurus_db.py` ; `thesaurus_engine.py` a un fallback au runtime, donc optionnel côté serveur). Les deux ajoutés et commentés par usage (serveur vs ETL).
- **`.env.example`** (nouveau) : les **11 variables d'env** lues par le code (`JL_DILA_DIR`, `JL_WAREHOUSE_*`, `THESAURUS_DB`, `PISTE_*`, `ANNUAIRE_*`) n'étaient documentées nulle part de façon exécutable — il fallait greper le code pour les découvrir. Listées, groupées par composant, avec rôle + défaut.
- **Docstring de `server.py`** : décrivait encore une V1 disparue (« Two data sources » admin, « Phase A: stdio transport »). C'est le premier fichier qu'un contributeur ouvre, et il désinformait sur la nature même du projet. Mise à jour : 31 tools, ~3,3 M décisions, CEDH/CJUE/articles versionnés, Streamable HTTP.

Vérifié : `server.py` compile ; `requirements.txt` se parse. Aucun changement de comportement runtime.

*(La liste `lxml` + `unidecode` vient d'un grep exhaustif des imports tierces — l'audit n'avait repéré que `lxml`.)*
