### PR TITLE
Fix warehouse : CODE_TO_LEGITEXT manquait CCom2 (dérive du +50 codes)

### DIFF
--- a/warehouse/warehouse_server.py
+++ b/warehouse/warehouse_server.py
@@ -71,6 +71,7 @@ CODE_TO_LEGITEXT: dict[str, str] = {
     "CSP":        "LEGITEXT000006072665",  # Code de la santé publique
     "CJA":        "LEGITEXT000006070933",  # Code de justice administrative
     "CGCT":       "LEGITEXT000006070633",  # Code général des collectivités territoriales
+    "CCom2":      "LEGITEXT000006070162",  # Code des communes (obsolète, remplacé par CGCT)
     "CRPA":       "LEGITEXT000031366350",  # Relations public-administration
     "CPI":        "LEGITEXT000006069414",  # Propriété intellectuelle
     "CASF":       "LEGITEXT000006074069",  # Action sociale et familles


### PR DESCRIPTION
Correctif ciblé, remonté par **votre propre suite de tests** (et que la CI de #12 attrapera désormais en continu).

## Le bug

`CCom2` (Code des communes, obsolète) a été ajouté à `sources/legi.py` (le commit « +50 codes LEGI ») mais **pas au mapping `CODE_TO_LEGITEXT` de `warehouse_server.py`** → `get_law_article(code="CCom2", …)` ne résout pas le LEGITEXT et échoue.

`tests/test_v2.py::test_warehouse_code_mapping` le détecte (il vérifie que chaque code de `legi.SUPPORTED_CODES` a son entrée côté warehouse) — c'est d'ailleurs ce test qui a fait rougir le run offline quand j'ai cadré la CI.

## Le fix

Ajout d'une ligne : `"CCom2": "LEGITEXT000006070162"`, placée près de `CGCT` (le code qui a remplacé le Code des communes).

## Vérification

`test_warehouse_code_mapping` passe ; balayage exhaustif → **44/44 codes** de `legi.SUPPORTED_CODES` désormais mappés, plus aucun manquant. `py_compile` OK.

*C'est un bon exemple de ce que la CI apporte : une dérive silencieuse entre deux fichiers, invisible à l'œil, attrapée par un test.*
